### PR TITLE
Harden config validation + defense-in-depth (review follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ pnpm db:generate    # drizzle-kit generate -> committed under packages/db/drizzl
 pnpm db:push        # apply schema to $DATABASE_URL (Neon)
 pnpm db:seed        # seed a fleet from a layout JSON (--config path or HARU_FLEET_LAYOUT)
 
+pnpm schemas:generate  # regenerate committed JSON Schemas for operator configs
+                       # (packages/protocol/schemas); drift-checked by a vitest test
+
 pnpm dev --filter=@haru/server       # via turbo (^build deps first), then tsx watch
 pnpm dev --filter=@haru/supervisor   # GPU-host agent; same ^build-then-watch shape
 ```

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -283,6 +283,9 @@ export default defineConfig(
       "n/no-process-exit": "off",
       "unicorn/no-process-exit": "off",
       "n/hashbang": "off",
+      // Generators/scripts import built (dist) or generated artifacts
+      // that may be absent until a prior build step runs.
+      "n/no-missing-import": "off",
     },
   },
 );

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from "oxfmt";
 // commas). `sortPackageJson` / `sortImports` stay disabled so
 // package.json key order stays as authored and import ordering stays
 // owned by ESLint's `import-x/order`. Markdown and YAML are excluded:
-// prose and workflow files are hand-managed.
+// prose and workflow files are hand-managed. The generated config JSON
+// Schemas are owned by their generator (JSON.stringify), so oxfmt must
+// not reformat them or `schemas:generate` output would fail the gate.
 export default defineConfig({
   printWidth: 80,
   tabWidth: 2,
@@ -13,5 +15,11 @@ export default defineConfig({
   trailingComma: "all",
   sortPackageJson: false,
   sortImports: false,
-  ignorePatterns: [".claude/**", "**/*.md", "**/*.yaml", "**/*.yml"],
+  ignorePatterns: [
+    ".claude/**",
+    "**/*.md",
+    "**/*.yaml",
+    "**/*.yml",
+    "packages/protocol/schemas/**",
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:generate": "pnpm --filter @haru/db db:generate",
     "db:migrate": "pnpm --filter @haru/db db:migrate",
     "db:push": "pnpm --filter @haru/db db:push",
-    "db:seed": "pnpm --filter @haru/db db:seed"
+    "db:seed": "pnpm --filter @haru/db db:seed",
+    "schemas:generate": "pnpm --filter @haru/protocol schemas:generate"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/core/src/route-intent.ts
+++ b/packages/core/src/route-intent.ts
@@ -23,6 +23,9 @@ export function isRoutableDomainState(domain: DomainSnapshot): boolean {
  */
 export function routableModels(domain: DomainSnapshot): RouteModel[] {
   const isStateRoutable = isRoutableDomainState(domain);
+  // Gating on the spec discriminant is equivalent to gating on the
+  // slot row's `kind`: slotSnapshotSchema enforces `kind === spec.kind`
+  // at the read boundary, so the two never disagree here.
   return domain.slots.flatMap((slot) =>
     slot.spec.kind === "inference"
       ? slot.spec.models.map((m) => ({
@@ -90,6 +93,11 @@ function toTarget(
   role: "active" | "standby",
 ): RouteTarget {
   const models = routableModels(domain);
+  // Per-model `eligible` is computed role-agnostically, so a just-
+  // demoted domain whose slots are still `serving` can report
+  // `models[].eligible === true` until sleep_vllm lands. That per-model
+  // flag is advisory for a standby; the target-level `eligible`/`weight`
+  // below (the contract consumers route on) is hard-forced off/zero.
   const isEligible =
     role === "active" &&
     domain.servingBaseUrl !== null &&

--- a/packages/db/drizzle/0002_bumpy_khan.sql
+++ b/packages/db/drizzle/0002_bumpy_khan.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "domains" ADD CONSTRAINT "domains_slug_valid" CHECK ("domains"."slug" ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND char_length("domains"."slug") <= 63);--> statement-breakpoint
+ALTER TABLE "fleets" ADD CONSTRAINT "fleets_slug_valid" CHECK ("fleets"."slug" ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND char_length("fleets"."slug") <= 63);--> statement-breakpoint
+ALTER TABLE "fleets" ADD CONSTRAINT "fleets_route_revision_positive" CHECK ("fleets"."route_revision" > 0);--> statement-breakpoint
+ALTER TABLE "slots" ADD CONSTRAINT "slots_gpu_index_nonnegative" CHECK ("slots"."gpu_index" >= 0);

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,629 @@
+{
+  "id": "05f89cc9-74f4-4cca-9d40-e2ad9a285c03",
+  "prevId": "1f15f5bc-7626-4b56-8ff8-3f8e8cfb9a21",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "domain_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement": {
+          "name": "placement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supervisor_url": {
+          "name": "supervisor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_base_url": {
+          "name": "serving_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_updated_at": {
+          "name": "state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_domains_fleet": {
+          "name": "idx_domains_fleet",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_fleet_id_fleets_id_fk": {
+          "name": "domains_fleet_id_fleets_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "fleets",
+          "columnsFrom": ["fleet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_domains_fleet_slug": {
+          "name": "uq_domains_fleet_slug",
+          "nullsNotDistinct": false,
+          "columns": ["fleet_id", "slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "domains_provider_valid": {
+          "name": "domains_provider_valid",
+          "value": "\"domains\".\"provider\" IN ('skypilot', 'skyserve', 'static')"
+        },
+        "domains_slug_valid": {
+          "name": "domains_slug_valid",
+          "value": "\"domains\".\"slug\" ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND char_length(\"domains\".\"slug\") <= 63"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_fleet": {
+          "name": "idx_events_fleet",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fleets": {
+      "name": "fleets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_domain_id": {
+          "name": "active_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_revision": {
+          "name": "route_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "policy": {
+          "name": "policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fleets_slug_unique": {
+          "name": "fleets_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "fleets_slug_valid": {
+          "name": "fleets_slug_valid",
+          "value": "\"fleets\".\"slug\" ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND char_length(\"fleets\".\"slug\") <= 63"
+        },
+        "fleets_route_revision_positive": {
+          "name": "fleets_route_revision_positive",
+          "value": "\"fleets\".\"route_revision\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fleet_id": {
+          "name": "fleet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "operation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "operation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "target_domain_id": {
+          "name": "target_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_domain_id": {
+          "name": "source_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_started_at": {
+          "name": "step_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "routing_committed": {
+          "name": "routing_committed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_operations_one_inflight_per_fleet": {
+          "name": "uq_operations_one_inflight_per_fleet",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operations\".\"state\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_operations_fleet": {
+          "name": "idx_operations_fleet",
+          "columns": [
+            {
+              "expression": "fleet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operations_fleet_id_fleets_id_fk": {
+          "name": "operations_fleet_id_fleets_id_fk",
+          "tableFrom": "operations",
+          "tableTo": "fleets",
+          "columnsFrom": ["fleet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "operations_target_domain_id_domains_id_fk": {
+          "name": "operations_target_domain_id_domains_id_fk",
+          "tableFrom": "operations",
+          "tableTo": "domains",
+          "columnsFrom": ["target_domain_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "operations_source_domain_id_domains_id_fk": {
+          "name": "operations_source_domain_id_domains_id_fk",
+          "tableFrom": "operations",
+          "tableTo": "domains",
+          "columnsFrom": ["source_domain_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slots": {
+      "name": "slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_index": {
+          "name": "gpu_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "slot_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "slot_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_updated_at": {
+          "name": "state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slots_domain": {
+          "name": "idx_slots_domain",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slots_domain_id_domains_id_fk": {
+          "name": "slots_domain_id_domains_id_fk",
+          "tableFrom": "slots",
+          "tableTo": "domains",
+          "columnsFrom": ["domain_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_slots_domain_gpu_kind": {
+          "name": "uq_slots_domain_gpu_kind",
+          "nullsNotDistinct": false,
+          "columns": ["domain_id", "gpu_index", "kind"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "slots_gpu_index_nonnegative": {
+          "name": "slots_gpu_index_nonnegative",
+          "value": "\"slots\".\"gpu_index\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.domain_state": {
+      "name": "domain_state",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "ready",
+        "degraded",
+        "failed",
+        "stopping",
+        "stopped"
+      ]
+    },
+    "public.operation_kind": {
+      "name": "operation_kind",
+      "schema": "public",
+      "values": ["promote", "demote"]
+    },
+    "public.operation_state": {
+      "name": "operation_state",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.slot_kind": {
+      "name": "slot_kind",
+      "schema": "public",
+      "values": ["inference", "training"]
+    },
+    "public.slot_state": {
+      "name": "slot_state",
+      "schema": "public",
+      "values": [
+        "starting",
+        "serving",
+        "sleeping",
+        "waking",
+        "probing",
+        "idle",
+        "training",
+        "stopping",
+        "failed",
+        "stopped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783833982467,
       "tag": "0001_reflective_payback",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784057020977,
+      "tag": "0002_bumpy_khan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/examples/fleet.example.json
+++ b/packages/db/examples/fleet.example.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../protocol/schemas/fleet-layout.schema.json",
   "slug": "default",
   "displayName": "Example fleet",
   "activeDomainSlug": "alpha",

--- a/packages/db/src/schema/domains.ts
+++ b/packages/db/src/schema/domains.ts
@@ -50,5 +50,10 @@ export const domains = pgTable(
       "domains_provider_valid",
       sql`${t.provider} IN ('skypilot', 'skyserve', 'static')`,
     ),
+    // Defense in depth behind the app-layer slugSchema (see fleets.ts).
+    check(
+      "domains_slug_valid",
+      sql`${t.slug} ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND char_length(${t.slug}) <= 63`,
+    ),
   ],
 );

--- a/packages/db/src/schema/fleets.ts
+++ b/packages/db/src/schema/fleets.ts
@@ -1,4 +1,6 @@
+import { sql } from "drizzle-orm";
 import {
+  check,
   integer,
   jsonb,
   pgTable,
@@ -9,26 +11,41 @@ import {
 
 import type { FleetPolicy } from "@haru/protocol";
 
-export const fleets = pgTable("fleets", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  slug: text("slug").notNull().unique(),
-  displayName: text("display_name"),
-  /**
-   * The single authoritative routing pointer. Nullable application
-   * level reference (a foreign key here would be circular with
-   * domains.fleet_id); the repository layer only ever writes ids read
-   * from this fleet's own domains, and moves the pointer exclusively
-   * through a compare-and-swap UPDATE.
-   */
-  activeDomainId: uuid("active_domain_id"),
-  /** Bumped on every active-pointer move; consumers order on it. */
-  routeRevision: integer("route_revision").notNull().default(1),
-  /** Partial FleetPolicy; parsed with defaults on read. */
-  policy: jsonb("policy").$type<Partial<FleetPolicy>>().notNull().default({}),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .defaultNow()
-    .notNull(),
-});
+export const fleets = pgTable(
+  "fleets",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    slug: text("slug").notNull().unique(),
+    displayName: text("display_name"),
+    /**
+     * The single authoritative routing pointer. Nullable application
+     * level reference (a foreign key here would be circular with
+     * domains.fleet_id); the repository layer only ever writes ids read
+     * from this fleet's own domains, and moves the pointer exclusively
+     * through a compare-and-swap UPDATE.
+     */
+    activeDomainId: uuid("active_domain_id"),
+    /** Bumped on every active-pointer move; consumers order on it. */
+    routeRevision: integer("route_revision").notNull().default(1),
+    /** Partial FleetPolicy; parsed with defaults on read. */
+    policy: jsonb("policy").$type<Partial<FleetPolicy>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => [
+    // Defense in depth behind the app-layer slugSchema: a slug is a
+    // lowercase, DNS-label-safe identifier with interior hyphens only,
+    // bounded to 63 chars (POSIX regex mirrors slugSchema, which uses a
+    // non-capturing group ERE cannot express).
+    check(
+      "fleets_slug_valid",
+      sql`${t.slug} ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND char_length(${t.slug}) <= 63`,
+    ),
+    // The routing revision only ever increments from its default of 1.
+    check("fleets_route_revision_positive", sql`${t.routeRevision} > 0`),
+  ],
+);

--- a/packages/db/src/schema/slots.ts
+++ b/packages/db/src/schema/slots.ts
@@ -1,4 +1,6 @@
+import { sql } from "drizzle-orm";
 import {
+  check,
   index,
   integer,
   jsonb,
@@ -38,5 +40,7 @@ export const slots = pgTable(
   (t) => [
     unique("uq_slots_domain_gpu_kind").on(t.domainId, t.gpuIndex, t.kind),
     index("idx_slots_domain").on(t.domainId),
+    // A GPU index is a physical device ordinal; never negative.
+    check("slots_gpu_index_nonnegative", sql`${t.gpuIndex} >= 0`),
   ],
 );

--- a/packages/driver-skyserve/src/driver.ts
+++ b/packages/driver-skyserve/src/driver.ts
@@ -100,9 +100,15 @@ export function createSkyserveDriver(
       if (!row) {
         return null;
       }
-      const status = row.find((token) =>
-        (SERVICE_STATUSES as readonly string[]).includes(token),
-      );
+      // Skip the NAME column (tokens[0], already matched against
+      // serviceName) when scanning for the status cell: a service whose
+      // name happens to be a status token must not shadow the real
+      // STATUS column.
+      const status = row
+        .slice(1)
+        .find((token) =>
+          (SERVICE_STATUSES as readonly string[]).includes(token),
+        );
       if (status === undefined) {
         throw new SkyCliError(
           `sky serve status ${serviceName}`,

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -16,7 +16,8 @@
     "lint": "oxlint --type-aware --deny-warnings . && eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "schemas:generate": "pnpm build && node scripts/generate-schemas.mjs"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/protocol/schemas/fleet-layout.schema.json
+++ b/packages/protocol/schemas/fleet-layout.schema.json
@@ -107,7 +107,6 @@
               "maximum": 9007199254740991
             }
           },
-          "required": ["prompt", "maxTokens"],
           "additionalProperties": false
         }
       },
@@ -128,14 +127,21 @@
           "provider": {
             "default": "static",
             "type": "string",
-            "enum": ["skypilot", "skyserve", "static"]
+            "enum": [
+              "skypilot",
+              "skyserve",
+              "static"
+            ]
           },
           "placement": {
             "type": "object",
             "properties": {
               "cloud": {
                 "type": "string",
-                "enum": ["aws", "gcp"]
+                "enum": [
+                  "aws",
+                  "gcp"
+                ]
               },
               "region": {
                 "type": "string",
@@ -159,9 +165,7 @@
             "required": [
               "cloud",
               "region",
-              "accelerator",
-              "acceleratorCount",
-              "useSpot"
+              "accelerator"
             ],
             "additionalProperties": false
           },
@@ -200,7 +204,10 @@
                             "format": "uri"
                           }
                         },
-                        "required": ["name", "servingUrl"],
+                        "required": [
+                          "name",
+                          "servingUrl"
+                        ],
                         "additionalProperties": false
                       }
                     },
@@ -215,7 +222,11 @@
                       "maximum": 9007199254740991
                     }
                   },
-                  "required": ["kind", "models", "sleepLevel", "gpuIndex"],
+                  "required": [
+                    "kind",
+                    "models",
+                    "gpuIndex"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -243,18 +254,30 @@
                       "maximum": 9007199254740991
                     }
                   },
-                  "required": ["kind", "command", "checkpointDir", "gpuIndex"],
+                  "required": [
+                    "kind",
+                    "command",
+                    "checkpointDir",
+                    "gpuIndex"
+                  ],
                   "additionalProperties": false
                 }
               ]
             }
           }
         },
-        "required": ["slug", "provider", "placement", "slots"],
+        "required": [
+          "slug",
+          "placement",
+          "slots"
+        ],
         "additionalProperties": false
       }
     }
   },
-  "required": ["slug", "domains"],
+  "required": [
+    "slug",
+    "domains"
+  ],
   "additionalProperties": false
 }

--- a/packages/protocol/schemas/fleet-layout.schema.json
+++ b/packages/protocol/schemas/fleet-layout.schema.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "activeDomainSlug": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "policy": {
+      "type": "object",
+      "properties": {
+        "autoFailover": {
+          "default": false,
+          "type": "boolean"
+        },
+        "heartbeatStaleMs": {
+          "default": 30000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "degradedGraceMs": {
+          "default": 60000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "trainingStopGraceMs": {
+          "default": 30000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "stopTrainingTimeoutMs": {
+          "default": 90000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "verifyGpuTimeoutMs": {
+          "default": 30000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "wakeTimeoutMs": {
+          "default": 120000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "probeTimeoutMs": {
+          "default": 60000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "switchActiveTimeoutMs": {
+          "default": 10000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "sleepTimeoutMs": {
+          "default": 60000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "startTrainingTimeoutMs": {
+          "default": 30000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 2147483647
+        },
+        "probe": {
+          "default": {
+            "prompt": "ping",
+            "maxTokens": 4
+          },
+          "type": "object",
+          "properties": {
+            "prompt": {
+              "default": "ping",
+              "type": "string",
+              "minLength": 1
+            },
+            "maxTokens": {
+              "default": 4,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["prompt", "maxTokens"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "domains": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          },
+          "provider": {
+            "default": "static",
+            "type": "string",
+            "enum": ["skypilot", "skyserve", "static"]
+          },
+          "placement": {
+            "type": "object",
+            "properties": {
+              "cloud": {
+                "type": "string",
+                "enum": ["aws", "gcp"]
+              },
+              "region": {
+                "type": "string",
+                "minLength": 1
+              },
+              "accelerator": {
+                "type": "string",
+                "minLength": 1
+              },
+              "acceleratorCount": {
+                "default": 1,
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "useSpot": {
+                "default": false,
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "cloud",
+              "region",
+              "accelerator",
+              "acceleratorCount",
+              "useSpot"
+            ],
+            "additionalProperties": false
+          },
+          "supervisorUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "servingBaseUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "slots": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "inference"
+                    },
+                    "models": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "servingUrl": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": ["name", "servingUrl"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "sleepLevel": {
+                      "default": 1,
+                      "type": "number",
+                      "const": 1
+                    },
+                    "gpuIndex": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": ["kind", "models", "sleepLevel", "gpuIndex"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "training"
+                    },
+                    "command": {
+                      "minItems": 1,
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "checkpointDir": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "gpuIndex": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": ["kind", "command", "checkpointDir", "gpuIndex"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
+        "required": ["slug", "provider", "placement", "slots"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["slug", "domains"],
+  "additionalProperties": false
+}

--- a/packages/protocol/schemas/supervisor-config.schema.json
+++ b/packages/protocol/schemas/supervisor-config.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "slots": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "inference"
+              },
+              "gpuIndex": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "models": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "port": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 65535
+                    }
+                  },
+                  "required": ["name", "port"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["kind", "gpuIndex", "models"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "training"
+              },
+              "gpuIndex": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "command": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "checkpointDir": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": ["kind", "gpuIndex", "command", "checkpointDir"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "required": ["slots"],
+  "additionalProperties": false
+}

--- a/packages/protocol/schemas/supervisor-config.schema.json
+++ b/packages/protocol/schemas/supervisor-config.schema.json
@@ -38,12 +38,19 @@
                       "maximum": 65535
                     }
                   },
-                  "required": ["name", "port"],
+                  "required": [
+                    "name",
+                    "port"
+                  ],
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["kind", "gpuIndex", "models"],
+            "required": [
+              "kind",
+              "gpuIndex",
+              "models"
+            ],
             "additionalProperties": false
           },
           {
@@ -71,13 +78,20 @@
                 "minLength": 1
               }
             },
-            "required": ["kind", "gpuIndex", "command", "checkpointDir"],
+            "required": [
+              "kind",
+              "gpuIndex",
+              "command",
+              "checkpointDir"
+            ],
             "additionalProperties": false
           }
         ]
       }
     }
   },
-  "required": ["slots"],
+  "required": [
+    "slots"
+  ],
   "additionalProperties": false
 }

--- a/packages/protocol/scripts/generate-schemas.mjs
+++ b/packages/protocol/scripts/generate-schemas.mjs
@@ -1,0 +1,26 @@
+/**
+ * Regenerate the bundled JSON Schemas for the operator-authored config
+ * files (fleet layout, supervisor config) from their zod schemas - the
+ * single source of truth. Operators point a `$schema` key at these so an
+ * editor can validate / autocomplete their config.
+ *
+ * Runs on plain node (no tsx dependency) by importing the BUILT helpers
+ * from dist, so `pnpm build` must run first - the `schemas:generate`
+ * script does that. The committed output is drift-checked by
+ * `json-schema.test.ts` (and in CI).
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  configSchemasByFile,
+  serializeJsonSchema,
+} from "../dist/json-schema.js";
+
+const schemasDirectory = fileURLToPath(new URL("../schemas/", import.meta.url));
+mkdirSync(schemasDirectory, { recursive: true });
+
+for (const [file, schema] of Object.entries(configSchemasByFile)) {
+  writeFileSync(`${schemasDirectory}${file}`, serializeJsonSchema(schema));
+  console.log(`wrote schemas/${file}`);
+}

--- a/packages/protocol/src/auth.test.ts
+++ b/packages/protocol/src/auth.test.ts
@@ -37,4 +37,14 @@ describe("isBearerTokenValid", () => {
     expect(isBearerTokenValid("Basic s3cret", "s3cret")).toBe(false);
     expect(isBearerTokenValid("Bearer ", "s3cret")).toBe(false);
   });
+
+  it("tolerates RFC 9110 optional whitespace around the credential", () => {
+    // Tab as the scheme/credential separator, and trailing SP/HTAB.
+    expect(isBearerTokenValid("Bearer\ts3cret", "s3cret")).toBe(true);
+    expect(isBearerTokenValid("Bearer s3cret ", "s3cret")).toBe(true);
+    expect(isBearerTokenValid("Bearer   s3cret\t", "s3cret")).toBe(true);
+    // Interior whitespace is still not part of the credential.
+    expect(isBearerTokenValid("Bearer s3 cret", "s3cret")).toBe(false);
+    expect(isBearerTokenValid("Bearer s3 cret", "s3")).toBe(false);
+  });
 });

--- a/packages/protocol/src/auth.ts
+++ b/packages/protocol/src/auth.ts
@@ -25,8 +25,11 @@ export function isBearerTokenValid(
   }
   // The auth scheme is case-insensitive per RFC 9110 ("bearer x" is
   // as valid as "Bearer x"); the credential itself is not. A bearer
-  // credential is a single b64token (no interior whitespace).
-  const match = /^bearer +(\S+)$/i.exec(authorizationHeader ?? "");
+  // credential is a single b64token (no interior whitespace). Accept
+  // RFC 9110 optional whitespace (SP / HTAB) around it so a
+  // tab-separated or trailing-padded header from a lenient client is
+  // not spuriously rejected; the credential capture stays `\S+`.
+  const match = /^bearer[ \t]+(\S+)[ \t]*$/i.exec(authorizationHeader ?? "");
   const presented = match?.[1] ?? "";
   return presented !== "" && isSameSecret(presented, expectedToken);
 }

--- a/packages/protocol/src/enums.ts
+++ b/packages/protocol/src/enums.ts
@@ -95,6 +95,12 @@ export type OperationStep = z.infer<typeof operationStepSchema>;
  * strictly interior: no leading, trailing, or consecutive hyphens, so
  * a slug is always a valid DNS label component (drivers derive
  * SkyPilot cluster / SkyServe service names from it).
+ *
+ * This is the INPUT validator (layout parse / config time). Reading an
+ * already-persisted slug back uses the more permissive
+ * `storedSlugSchema` below: a slug is stored verbatim in a plain text
+ * column, so tightening THIS regex must never be able to reject a slug
+ * an older release already wrote to the database.
  */
 export const slugSchema = z
   .string()
@@ -104,3 +110,20 @@ export const slugSchema = z
     message: "slug must be lowercase alphanumeric with inner hyphens",
   });
 export type Slug = z.infer<typeof slugSchema>;
+
+/**
+ * Lenient slug validator for READ models (domain/fleet snapshots, route
+ * intent). It accepts every slug any past release could have persisted
+ * - including the trailing / consecutive-hyphen forms the original
+ * `slugSchema` allowed - so tightening the input contract can never
+ * brick reading back an existing fleet (which would 500 the chat hot
+ * path). Charset and length are still bounded; only a leading hyphen
+ * and empties are rejected, exactly as the historical writer did.
+ */
+export const storedSlugSchema = z
+  .string()
+  .min(1)
+  .max(63)
+  .regex(/^[a-z0-9][a-z0-9-]*$/, {
+    message: "stored slug must be lowercase alphanumeric with hyphens",
+  });

--- a/packages/protocol/src/enums.ts
+++ b/packages/protocol/src/enums.ts
@@ -90,12 +90,17 @@ export const operationStepSchema = z.enum([
 ]);
 export type OperationStep = z.infer<typeof operationStepSchema>;
 
-/** URL-safe identifier used for fleet and domain slugs. */
+/**
+ * URL-safe identifier used for fleet and domain slugs. Hyphens are
+ * strictly interior: no leading, trailing, or consecutive hyphens, so
+ * a slug is always a valid DNS label component (drivers derive
+ * SkyPilot cluster / SkyServe service names from it).
+ */
 export const slugSchema = z
   .string()
   .min(1)
   .max(63)
-  .regex(/^[a-z0-9][a-z0-9-]*$/, {
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
     message: "slug must be lowercase alphanumeric with inner hyphens",
   });
 export type Slug = z.infer<typeof slugSchema>;

--- a/packages/protocol/src/enums.ts
+++ b/packages/protocol/src/enums.ts
@@ -94,13 +94,10 @@ export type OperationStep = z.infer<typeof operationStepSchema>;
  * URL-safe identifier used for fleet and domain slugs. Hyphens are
  * strictly interior: no leading, trailing, or consecutive hyphens, so
  * a slug is always a valid DNS label component (drivers derive
- * SkyPilot cluster / SkyServe service names from it).
- *
- * This is the INPUT validator (layout parse / config time). Reading an
- * already-persisted slug back uses the more permissive
- * `storedSlugSchema` below: a slug is stored verbatim in a plain text
- * column, so tightening THIS regex must never be able to reject a slug
- * an older release already wrote to the database.
+ * SkyPilot cluster / SkyServe service names from it). One slug
+ * contract, enforced everywhere: the same strict validator guards
+ * config input and snapshot read-back, so a slug that violates it can
+ * neither be written nor silently read back.
  */
 export const slugSchema = z
   .string()
@@ -110,20 +107,3 @@ export const slugSchema = z
     message: "slug must be lowercase alphanumeric with inner hyphens",
   });
 export type Slug = z.infer<typeof slugSchema>;
-
-/**
- * Lenient slug validator for READ models (domain/fleet snapshots, route
- * intent). It accepts every slug any past release could have persisted
- * - including the trailing / consecutive-hyphen forms the original
- * `slugSchema` allowed - so tightening the input contract can never
- * brick reading back an existing fleet (which would 500 the chat hot
- * path). Charset and length are still bounded; only a leading hyphen
- * and empties are rejected, exactly as the historical writer did.
- */
-export const storedSlugSchema = z
-  .string()
-  .min(1)
-  .max(63)
-  .regex(/^[a-z0-9][a-z0-9-]*$/, {
-    message: "stored slug must be lowercase alphanumeric with hyphens",
-  });

--- a/packages/protocol/src/fleet.ts
+++ b/packages/protocol/src/fleet.ts
@@ -5,7 +5,7 @@ import {
   domainStateSchema,
   slotKindSchema,
   slotStateSchema,
-  slugSchema,
+  storedSlugSchema,
 } from "./enums.js";
 import { placementSpecSchema } from "./placement.js";
 import { fleetPolicySchema } from "./policy.js";
@@ -100,7 +100,7 @@ export type SlotSnapshot = z.infer<typeof slotSnapshotSchema>;
 export const domainSnapshotSchema = z.object({
   id: z.uuid(),
   fleetId: z.uuid(),
-  slug: slugSchema,
+  slug: storedSlugSchema,
   state: domainStateSchema,
   provider: domainProviderSchema,
   placement: placementSpecSchema,
@@ -127,7 +127,7 @@ export type DomainSnapshot = z.infer<typeof domainSnapshotSchema>;
  */
 export const fleetSnapshotSchema = z.object({
   id: z.uuid(),
-  slug: slugSchema,
+  slug: storedSlugSchema,
   displayName: z.string().nullable(),
   activeDomainId: z.uuid().nullable(),
   routeRevision: z.number().int().positive(),

--- a/packages/protocol/src/fleet.ts
+++ b/packages/protocol/src/fleet.ts
@@ -25,7 +25,7 @@ export const httpUrlSchema = z.url({ protocol: /^https?$/ });
  * the vLLM server that hosts it. Multiple models on one GPU slot means
  * multiple vLLM server processes sharing that GPU.
  */
-export const modelBindingSchema = z.object({
+export const modelBindingSchema = z.strictObject({
   // Lowercase-only: this is the routing key clients put in `model`,
   // matched exactly by the chat proxy. Requiring lowercase here turns
   // a client/server casing mismatch (many callers normalise model ids
@@ -46,8 +46,12 @@ export type ModelBinding = z.infer<typeof modelBindingSchema>;
  * Inference slot spec: which models this GPU serves. `sleepLevel: 1`
  * is the only supported standby mode in this slice (vLLM level 1
  * sleep keeps weights in CPU RAM for the fastest wake path).
+ *
+ * Strict: operator-authored config; unknown keys (e.g. a misspelled
+ * `sleepLevel`) fail at parse time. `slotLayoutSchema` extends this
+ * with `gpuIndex` and inherits the strictness.
  */
-export const inferenceSlotSpecSchema = z.object({
+export const inferenceSlotSpecSchema = z.strictObject({
   kind: z.literal("inference"),
   models: z.array(modelBindingSchema).min(1),
   sleepLevel: z.literal(1).default(1),
@@ -60,7 +64,7 @@ export type InferenceSlotSpec = z.infer<typeof inferenceSlotSpecSchema>;
  * checkpoint/resume oriented; the supervisor may SIGKILL it after the
  * configured grace period during failover.
  */
-export const trainingSlotSpecSchema = z.object({
+export const trainingSlotSpecSchema = z.strictObject({
   kind: z.literal("training"),
   command: z.array(z.string().min(1)).min(1),
   checkpointDir: z.string().min(1),
@@ -73,14 +77,24 @@ export const slotSpecSchema = z.discriminatedUnion("kind", [
 ]);
 export type SlotSpec = z.infer<typeof slotSpecSchema>;
 
-export const slotSnapshotSchema = z.object({
-  id: z.uuid(),
-  domainId: z.uuid(),
-  gpuIndex: z.number().int().nonnegative(),
-  kind: slotKindSchema,
-  state: slotStateSchema,
-  spec: slotSpecSchema,
-});
+export const slotSnapshotSchema = z
+  .object({
+    id: z.uuid(),
+    domainId: z.uuid(),
+    gpuIndex: z.number().int().nonnegative(),
+    kind: slotKindSchema,
+    state: slotStateSchema,
+    spec: slotSpecSchema,
+  })
+  // The row's `kind` column and the spec discriminant are written
+  // together by applyFleetLayout; enforce they agree at the read
+  // boundary so a drifted row can never surface as (say) an inference
+  // slot carrying a training spec. Routing and health predicates then
+  // gate on either interchangeably.
+  .refine((slot) => slot.kind === slot.spec.kind, {
+    message: "slot.kind must match slot.spec.kind",
+    path: ["kind"],
+  });
 export type SlotSnapshot = z.infer<typeof slotSnapshotSchema>;
 
 export const domainSnapshotSchema = z.object({

--- a/packages/protocol/src/fleet.ts
+++ b/packages/protocol/src/fleet.ts
@@ -5,7 +5,7 @@ import {
   domainStateSchema,
   slotKindSchema,
   slotStateSchema,
-  storedSlugSchema,
+  slugSchema,
 } from "./enums.js";
 import { placementSpecSchema } from "./placement.js";
 import { fleetPolicySchema } from "./policy.js";
@@ -100,7 +100,7 @@ export type SlotSnapshot = z.infer<typeof slotSnapshotSchema>;
 export const domainSnapshotSchema = z.object({
   id: z.uuid(),
   fleetId: z.uuid(),
-  slug: storedSlugSchema,
+  slug: slugSchema,
   state: domainStateSchema,
   provider: domainProviderSchema,
   placement: placementSpecSchema,
@@ -127,7 +127,7 @@ export type DomainSnapshot = z.infer<typeof domainSnapshotSchema>;
  */
 export const fleetSnapshotSchema = z.object({
   id: z.uuid(),
-  slug: storedSlugSchema,
+  slug: slugSchema,
   displayName: z.string().nullable(),
   activeDomainId: z.uuid().nullable(),
   routeRevision: z.number().int().positive(),

--- a/packages/protocol/src/json-schema.test.ts
+++ b/packages/protocol/src/json-schema.test.ts
@@ -3,18 +3,63 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { configSchemasByFile, toConfigJsonSchema } from "./json-schema.js";
+import {
+  configSchemasByFile,
+  serializeJsonSchema,
+  toConfigJsonSchema,
+} from "./json-schema.js";
+
+type JsonNode = Record<string, unknown>;
+
+/** Every JSON Schema node that declares `properties`, reachable anywhere
+ * in the tree (through properties, items, oneOf/anyOf, ...). */
+function objectNodes(node: unknown): JsonNode[] {
+  if (node === null || typeof node !== "object") {
+    return [];
+  }
+  const record = node as JsonNode;
+  const found: JsonNode[] = [];
+  if (typeof record.properties === "object" && record.properties !== null) {
+    found.push(record);
+  }
+  for (const value of Object.values(record)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        found.push(...objectNodes(item));
+      }
+    } else {
+      found.push(...objectNodes(value));
+    }
+  }
+  return found;
+}
 
 describe("bundled config JSON Schemas", () => {
   for (const [file, schema] of Object.entries(configSchemasByFile)) {
-    it(`schemas/${file} is committed in sync with its zod schema`, () => {
+    it(`schemas/${file} is committed byte-for-byte in sync with its zod schema`, () => {
       const path = fileURLToPath(
         new URL(`../schemas/${file}`, import.meta.url),
       );
-      const committed: unknown = JSON.parse(readFileSync(path, "utf8"));
-      // Content, not formatting (oxfmt owns the file's whitespace). If
-      // this fails, a config schema changed: run `pnpm schemas:generate`.
-      expect(committed).toEqual(toConfigJsonSchema(schema));
+      const committed = readFileSync(path, "utf8");
+      // oxfmt ignores schemas/, so the committed bytes ARE the generator's.
+      // Regenerate with `pnpm schemas:generate` if this fails.
+      expect(committed).toBe(serializeJsonSchema(schema));
+    });
+
+    it(`schemas/${file} keeps defaulted (optional) fields out of "required"`, () => {
+      // io:"input" mode: a field with a zod .default() is OPTIONAL for the
+      // author, so it must never be marked required - otherwise an editor
+      // flags a valid config (incl. the shipped example) that omits it.
+      const nodes = objectNodes(toConfigJsonSchema(schema));
+      for (const node of nodes) {
+        const properties = node.properties as Record<string, JsonNode>;
+        const required = Array.isArray(node.required) ? node.required : [];
+        const defaultedButRequired = required.filter(
+          (key: unknown) =>
+            typeof key === "string" && properties[key]?.default !== undefined,
+        );
+        expect(defaultedButRequired).toEqual([]);
+      }
     });
   }
 });

--- a/packages/protocol/src/json-schema.test.ts
+++ b/packages/protocol/src/json-schema.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { configSchemasByFile, toConfigJsonSchema } from "./json-schema.js";
+
+describe("bundled config JSON Schemas", () => {
+  for (const [file, schema] of Object.entries(configSchemasByFile)) {
+    it(`schemas/${file} is committed in sync with its zod schema`, () => {
+      const path = fileURLToPath(
+        new URL(`../schemas/${file}`, import.meta.url),
+      );
+      const committed: unknown = JSON.parse(readFileSync(path, "utf8"));
+      // Content, not formatting (oxfmt owns the file's whitespace). If
+      // this fails, a config schema changed: run `pnpm schemas:generate`.
+      expect(committed).toEqual(toConfigJsonSchema(schema));
+    });
+  }
+});

--- a/packages/protocol/src/json-schema.ts
+++ b/packages/protocol/src/json-schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+import { fleetLayoutSchema } from "./layout.js";
+import { supervisorConfigSchema } from "./supervisor.js";
+
+/**
+ * The operator-authored config schemas, keyed by the basename of the
+ * bundled JSON Schema file that describes them. `scripts/generate-
+ * schemas.ts` writes these files; `json-schema.test.ts` drift-checks the
+ * committed output against a fresh conversion so the two never diverge.
+ */
+export const configSchemasByFile: Record<string, z.ZodType> = {
+  "fleet-layout.schema.json": fleetLayoutSchema,
+  "supervisor-config.schema.json": supervisorConfigSchema,
+};
+
+/**
+ * Convert one operator-config schema to a JSON Schema with haru's fixed
+ * options, so the generator and the drift test always agree.
+ * `unrepresentable: "any"` degrades the cross-field refinements JSON
+ * Schema cannot express (dup-slug, dup-(gpuIndex,kind), unique model
+ * names) to an unconstrained node rather than throwing - the structural
+ * shape is what an editor needs; the loader still enforces the rest.
+ */
+export function toConfigJsonSchema(schema: z.ZodType): unknown {
+  return z.toJSONSchema(schema, { unrepresentable: "any" });
+}
+
+/** Byte-exact serialization the generator writes and the test asserts. */
+export function serializeJsonSchema(schema: z.ZodType): string {
+  return `${JSON.stringify(toConfigJsonSchema(schema), null, 2)}\n`;
+}

--- a/packages/protocol/src/json-schema.ts
+++ b/packages/protocol/src/json-schema.ts
@@ -6,7 +6,7 @@ import { supervisorConfigSchema } from "./supervisor.js";
 /**
  * The operator-authored config schemas, keyed by the basename of the
  * bundled JSON Schema file that describes them. `scripts/generate-
- * schemas.ts` writes these files; `json-schema.test.ts` drift-checks the
+ * schemas.mjs` writes these files; `json-schema.test.ts` drift-checks the
  * committed output against a fresh conversion so the two never diverge.
  */
 export const configSchemasByFile: Record<string, z.ZodType> = {

--- a/packages/protocol/src/json-schema.ts
+++ b/packages/protocol/src/json-schema.ts
@@ -17,13 +17,21 @@ export const configSchemasByFile: Record<string, z.ZodType> = {
 /**
  * Convert one operator-config schema to a JSON Schema with haru's fixed
  * options, so the generator and the drift test always agree.
+ *
+ * `io: "input"` is essential: these schemas validate the config an
+ * operator AUTHORS, where a field with a `.default()` (provider,
+ * useSpot, sleepLevel, ...) is OPTIONAL. The default "output" mode
+ * describes the PARSED value, where every defaulted field is always
+ * present and thus `required` - which would make an editor wrongly flag
+ * a valid layout that omits a default (including the shipped example).
+ *
  * `unrepresentable: "any"` degrades the cross-field refinements JSON
  * Schema cannot express (dup-slug, dup-(gpuIndex,kind), unique model
  * names) to an unconstrained node rather than throwing - the structural
  * shape is what an editor needs; the loader still enforces the rest.
  */
 export function toConfigJsonSchema(schema: z.ZodType): unknown {
-  return z.toJSONSchema(schema, { unrepresentable: "any" });
+  return z.toJSONSchema(schema, { io: "input", unrepresentable: "any" });
 }
 
 /** Byte-exact serialization the generator writes and the test asserts. */

--- a/packages/protocol/src/layout.ts
+++ b/packages/protocol/src/layout.ts
@@ -25,7 +25,10 @@ export const slotLayoutSchema = z.discriminatedUnion("kind", [
 ]);
 export type SlotLayout = z.infer<typeof slotLayoutSchema>;
 
-export const domainLayoutSchema = z.object({
+// Strict: operator-authored config. A misspelled key (e.g.
+// `supervisorUrl` -> `superviorUrl`) must fail at parse time rather
+// than silently leave the domain with a null control URL.
+export const domainLayoutSchema = z.strictObject({
   slug: slugSchema,
   provider: domainProviderSchema.default("static"),
   placement: placementSpecSchema,
@@ -36,7 +39,9 @@ export const domainLayoutSchema = z.object({
 export type DomainLayout = z.infer<typeof domainLayoutSchema>;
 
 export const fleetLayoutSchema = z
-  .object({
+  // Strict: the top-level operator layout rejects unknown keys so a
+  // typo'd field is a config-time error, not a silently ignored one.
+  .strictObject({
     slug: slugSchema,
     displayName: z.string().min(1).optional(),
     /** Slug of the domain that starts active; must name a domain below. */

--- a/packages/protocol/src/layout.ts
+++ b/packages/protocol/src/layout.ts
@@ -42,6 +42,9 @@ export const fleetLayoutSchema = z
   // Strict: the top-level operator layout rejects unknown keys so a
   // typo'd field is a config-time error, not a silently ignored one.
   .strictObject({
+    /** Optional pointer to the bundled JSON Schema, so an editor can
+     * validate / autocomplete the layout. Ignored by the loader. */
+    $schema: z.string().optional(),
     slug: slugSchema,
     displayName: z.string().min(1).optional(),
     /** Slug of the domain that starts active; must name a domain below. */

--- a/packages/protocol/src/operations.ts
+++ b/packages/protocol/src/operations.ts
@@ -27,12 +27,15 @@ export const operationSnapshotSchema = z.object({
 });
 export type OperationSnapshot = z.infer<typeof operationSnapshotSchema>;
 
-export const promoteRequestSchema = z.object({
+// Strict: these are the server's own control-API request bodies. Client
+// and server ship from one repo and version together, so an unknown key
+// is a typo / drift, not a compatible extension - reject it at the edge.
+export const promoteRequestSchema = z.strictObject({
   targetDomainId: z.uuid(),
 });
 export type PromoteRequest = z.infer<typeof promoteRequestSchema>;
 
-export const demoteRequestSchema = z.object({
+export const demoteRequestSchema = z.strictObject({
   targetDomainId: z.uuid(),
 });
 export type DemoteRequest = z.infer<typeof demoteRequestSchema>;

--- a/packages/protocol/src/placement.ts
+++ b/packages/protocol/src/placement.ts
@@ -9,8 +9,12 @@ import { z } from "zod";
  * `accelerator` is the SkyPilot accelerator name (see `sky show-gpus`).
  * It is deliberately required with no default: haru is a library and
  * does not hard-code any particular GPU model.
+ *
+ * Strict: operator-authored config, so a misspelled key (e.g.
+ * `acceleratorCount` -> `acceleratorCnt`) fails at parse time instead
+ * of silently reverting to the default.
  */
-export const placementSpecSchema = z.object({
+export const placementSpecSchema = z.strictObject({
   cloud: z.enum(["aws", "gcp"]),
   region: z.string().min(1),
   accelerator: z.string().min(1),

--- a/packages/protocol/src/policy.ts
+++ b/packages/protocol/src/policy.ts
@@ -9,8 +9,10 @@ import { z } from "zod";
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const timeoutMsSchema = z.number().int().positive().max(MAX_TIMEOUT_MS);
 
-/** Synthetic inference probe configuration. */
-export const probePolicySchema = z.object({
+/** Synthetic inference probe configuration. Strict: this is
+ * operator-authored config, so a misspelled key must fail at parse
+ * time rather than be silently dropped. */
+export const probePolicySchema = z.strictObject({
   prompt: z.string().min(1).default("ping"),
   maxTokens: z.number().int().positive().default(4),
 });
@@ -25,8 +27,13 @@ export type ProbePolicy = z.infer<typeof probePolicySchema>;
  * moment the reconciler enters the step. Training checkpointing is
  * best-effort inside `trainingStopGraceMs`; failover is never blocked
  * waiting for a perfect checkpoint.
+ *
+ * Strict: a misspelled key (e.g. `autoFailver`) must be a config-time
+ * error, not a silently dropped field that leaves a safety setting
+ * like `autoFailover` at its default. `.partial()` in the layout
+ * schema inherits this strictness.
  */
-export const fleetPolicySchema = z.object({
+export const fleetPolicySchema = z.strictObject({
   /** Automatically promote a standby when the active goes stale. */
   autoFailover: z.boolean().default(false),
   /** Active domain heartbeat staleness threshold. */

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { chatCompletionRequestSchema } from "./chat.js";
-import { operationStepSchema, slugSchema, storedSlugSchema } from "./enums.js";
+import { operationStepSchema, slugSchema } from "./enums.js";
 import { errorBody } from "./errors.js";
 import {
   domainRole,
@@ -37,23 +37,6 @@ describe("slugSchema", () => {
     expect(() => slugSchema.parse("alpha-")).toThrow();
     expect(() => slugSchema.parse("a--b")).toThrow();
     expect(() => slugSchema.parse("-")).toThrow();
-  });
-});
-
-describe("storedSlugSchema (read-back tolerance)", () => {
-  it("accepts legacy slugs the tightened input slugSchema now rejects", () => {
-    // These were writable under the original slugSchema, so they can sit
-    // in a live DB; reading a snapshot / route intent back must not throw
-    // just because the INPUT contract was later tightened.
-    for (const legacy of ["prod-", "us--east", "a--b"]) {
-      expect(() => slugSchema.parse(legacy)).toThrow();
-      expect(storedSlugSchema.parse(legacy)).toBe(legacy);
-    }
-  });
-
-  it("still rejects a leading hyphen and empty (never writable)", () => {
-    expect(() => storedSlugSchema.parse("-x")).toThrow();
-    expect(() => storedSlugSchema.parse("")).toThrow();
   });
 });
 

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { chatCompletionRequestSchema } from "./chat.js";
-import { operationStepSchema, slugSchema } from "./enums.js";
+import { operationStepSchema, slugSchema, storedSlugSchema } from "./enums.js";
 import { errorBody } from "./errors.js";
 import {
   domainRole,
@@ -37,6 +37,23 @@ describe("slugSchema", () => {
     expect(() => slugSchema.parse("alpha-")).toThrow();
     expect(() => slugSchema.parse("a--b")).toThrow();
     expect(() => slugSchema.parse("-")).toThrow();
+  });
+});
+
+describe("storedSlugSchema (read-back tolerance)", () => {
+  it("accepts legacy slugs the tightened input slugSchema now rejects", () => {
+    // These were writable under the original slugSchema, so they can sit
+    // in a live DB; reading a snapshot / route intent back must not throw
+    // just because the INPUT contract was later tightened.
+    for (const legacy of ["prod-", "us--east", "a--b"]) {
+      expect(() => slugSchema.parse(legacy)).toThrow();
+      expect(storedSlugSchema.parse(legacy)).toBe(legacy);
+    }
+  });
+
+  it("still rejects a leading hyphen and empty (never writable)", () => {
+    expect(() => storedSlugSchema.parse("-x")).toThrow();
+    expect(() => storedSlugSchema.parse("")).toThrow();
   });
 });
 
@@ -359,6 +376,22 @@ describe("fleetLayoutSchema", () => {
         ],
       }),
     ).toThrow();
+    // Nested-policy typo: proves `fleetPolicySchema.partial()` keeps the
+    // strictness, so a misspelled safety setting inside a layout's
+    // `policy` is still a config-time error.
+    expect(() =>
+      fleetLayoutSchema.parse({
+        ...validLayout,
+        policy: { autoFailver: true },
+      }),
+    ).toThrow();
+    // ...while a correctly-spelled partial policy is still accepted.
+    expect(() =>
+      fleetLayoutSchema.parse({
+        ...validLayout,
+        policy: { autoFailover: true },
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -550,6 +550,18 @@ describe("joinUrl", () => {
       "https://host.example/base/evil.example",
     );
   });
+
+  it("does not let leading backslashes swap the origin", () => {
+    // The WHATWG URL parser treats a backslash like a slash on http(s),
+    // so a backslash-led path against an origin-only base (e.g. a
+    // supervisor 127.0.0.1 URL) must not resolve to another host.
+    expect(joinUrl("https://host.example", String.raw`\\evil.example/x`)).toBe(
+      "https://host.example/evil.example/x",
+    );
+    expect(joinUrl("https://host.example", String.raw`/\evil.example`)).toBe(
+      "https://host.example/evil.example",
+    );
+  });
 });
 
 describe("errorBody", () => {

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -12,12 +12,14 @@ import {
   trainingSlotSpecSchema,
 } from "./fleet.js";
 import { fleetLayoutSchema } from "./layout.js";
+import { demoteRequestSchema, promoteRequestSchema } from "./operations.js";
 import { placementSpecSchema } from "./placement.js";
 import { fleetPolicySchema, resolveFleetPolicy } from "./policy.js";
 import {
   probeRequestSchema,
   supervisorConfigSchema,
   trainingStopRequestSchema,
+  vllmTargetRequestSchema,
 } from "./supervisor.js";
 import { joinUrl } from "./url.js";
 
@@ -376,6 +378,15 @@ describe("fleetLayoutSchema", () => {
       }),
     ).not.toThrow();
   });
+
+  it("accepts an optional $schema pointer for editor integration", () => {
+    expect(() =>
+      fleetLayoutSchema.parse({
+        ...validLayout,
+        $schema: "../../protocol/schemas/fleet-layout.schema.json",
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("probeRequestSchema", () => {
@@ -397,6 +408,34 @@ describe("trainingStopRequestSchema", () => {
     );
     expect(() =>
       trainingStopRequestSchema.parse({ graceMs: 2_147_483_648 }),
+    ).toThrow();
+  });
+});
+
+describe("internal request DTOs are strict", () => {
+  it("rejects unknown keys on control-API request bodies", () => {
+    // Server control API (client and server ship together).
+    expect(() =>
+      promoteRequestSchema.parse({
+        targetDomainId: "00000000-0000-4000-8000-00000000000a",
+        force: true,
+      }),
+    ).toThrow();
+    expect(() =>
+      demoteRequestSchema.parse({
+        targetDomainId: "00000000-0000-4000-8000-00000000000a",
+        extra: 1,
+      }),
+    ).toThrow();
+    // Supervisor inbound (server is the only caller).
+    expect(() =>
+      vllmTargetRequestSchema.parse({ gpuIndex: 0, all: true }),
+    ).toThrow();
+    expect(() =>
+      trainingStopRequestSchema.parse({ graceMs: 5000, hard: true }),
+    ).toThrow();
+    expect(() =>
+      probeRequestSchema.parse({ prompt: "ping", prmpt: "typo" }),
     ).toThrow();
   });
 });

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -6,13 +6,19 @@ import { errorBody } from "./errors.js";
 import {
   domainRole,
   inferenceSlotSpecSchema,
+  modelBindingSchema,
+  slotSnapshotSchema,
   slotSpecSchema,
   trainingSlotSpecSchema,
 } from "./fleet.js";
 import { fleetLayoutSchema } from "./layout.js";
 import { placementSpecSchema } from "./placement.js";
 import { fleetPolicySchema, resolveFleetPolicy } from "./policy.js";
-import { probeRequestSchema, trainingStopRequestSchema } from "./supervisor.js";
+import {
+  probeRequestSchema,
+  supervisorConfigSchema,
+  trainingStopRequestSchema,
+} from "./supervisor.js";
 import { joinUrl } from "./url.js";
 
 describe("slugSchema", () => {
@@ -25,6 +31,12 @@ describe("slugSchema", () => {
     expect(() => slugSchema.parse("Alpha")).toThrow();
     expect(() => slugSchema.parse("-alpha")).toThrow();
     expect(() => slugSchema.parse("")).toThrow();
+  });
+
+  it("rejects trailing and consecutive hyphens (hyphens are interior)", () => {
+    expect(() => slugSchema.parse("alpha-")).toThrow();
+    expect(() => slugSchema.parse("a--b")).toThrow();
+    expect(() => slugSchema.parse("-")).toThrow();
   });
 });
 
@@ -54,6 +66,18 @@ describe("placementSpecSchema", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects an unknown key (strict operator config)", () => {
+    expect(() =>
+      placementSpecSchema.parse({
+        cloud: "aws",
+        region: "us-east-1",
+        accelerator: "SOME-GPU",
+        // A misspelled acceleratorCount must not be silently dropped.
+        acceleratorCnt: 4,
+      }),
+    ).toThrow();
+  });
 });
 
 describe("fleetPolicySchema", () => {
@@ -74,6 +98,13 @@ describe("fleetPolicySchema", () => {
     const policy = resolveFleetPolicy({ autoFailover: true });
     expect(policy.autoFailover).toBe(true);
     expect(policy.heartbeatStaleMs).toBe(30_000);
+  });
+
+  it("rejects a misspelled key instead of silently dropping it", () => {
+    // The whole point of strict: a typo'd safety setting must be a
+    // config-time error, not a silently-defaulted autoFailover=false.
+    expect(() => fleetPolicySchema.parse({ autoFailver: true })).toThrow();
+    expect(() => resolveFleetPolicy({ autoFailver: true })).toThrow();
   });
 });
 
@@ -106,6 +137,48 @@ describe("slotSpecSchema", () => {
 
   it("discriminates on kind", () => {
     expect(() => slotSpecSchema.parse({ kind: "other" })).toThrow();
+  });
+
+  it("rejects unknown keys on specs and model bindings (strict)", () => {
+    expect(() =>
+      inferenceSlotSpecSchema.parse({
+        kind: "inference",
+        models: [{ name: "example-chat", servingUrl: "http://127.0.0.1:8001" }],
+        sleepLvl: 1,
+      }),
+    ).toThrow();
+    expect(() =>
+      modelBindingSchema.parse({
+        name: "example-chat",
+        servingUrl: "http://127.0.0.1:8001",
+        serving_url: "http://127.0.0.1:8002",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("slotSnapshotSchema", () => {
+  const inferenceSnapshot = {
+    id: "00000000-0000-4000-8000-00000000000a",
+    domainId: "00000000-0000-4000-8000-00000000000b",
+    gpuIndex: 0,
+    kind: "inference",
+    state: "serving",
+    spec: {
+      kind: "inference",
+      sleepLevel: 1,
+      models: [{ name: "example-chat", servingUrl: "http://127.0.0.1:8001" }],
+    },
+  };
+
+  it("accepts a slot whose kind matches its spec discriminant", () => {
+    expect(slotSnapshotSchema.parse(inferenceSnapshot).kind).toBe("inference");
+  });
+
+  it("rejects a row whose kind disagrees with its spec discriminant", () => {
+    expect(() =>
+      slotSnapshotSchema.parse({ ...inferenceSnapshot, kind: "training" }),
+    ).toThrow(/kind must match/);
   });
 });
 
@@ -259,6 +332,34 @@ describe("fleetLayoutSchema", () => {
       }),
     ).not.toThrow();
   });
+
+  it("rejects unknown keys at every level (strict, incl. extended slots)", () => {
+    const domain = validLayout.domains[0]!;
+    // Top-level typo.
+    expect(() =>
+      fleetLayoutSchema.parse({ ...validLayout, autoFailover: true }),
+    ).toThrow();
+    // Domain-level typo.
+    expect(() =>
+      fleetLayoutSchema.parse({
+        ...validLayout,
+        domains: [{ ...domain, superviorUrl: "http://127.0.0.1:8701" }],
+      }),
+    ).toThrow();
+    // Slot-level typo: proves the `.extend({ gpuIndex })` on the slot
+    // spec inherits strictness rather than reopening the object.
+    expect(() =>
+      fleetLayoutSchema.parse({
+        ...validLayout,
+        domains: [
+          {
+            ...domain,
+            slots: [{ ...domain.slots[0], sleepLvl: 1 }, domain.slots[1]],
+          },
+        ],
+      }),
+    ).toThrow();
+  });
 });
 
 describe("probeRequestSchema", () => {
@@ -280,6 +381,41 @@ describe("trainingStopRequestSchema", () => {
     );
     expect(() =>
       trainingStopRequestSchema.parse({ graceMs: 2_147_483_648 }),
+    ).toThrow();
+  });
+});
+
+describe("supervisorConfigSchema", () => {
+  const validConfig = {
+    slots: [
+      {
+        kind: "inference",
+        gpuIndex: 0,
+        models: [{ name: "example-chat", port: 8001 }],
+      },
+    ],
+  };
+
+  it("parses a valid config", () => {
+    expect(supervisorConfigSchema.parse(validConfig).slots).toHaveLength(1);
+  });
+
+  it("rejects unknown keys (strict operator config)", () => {
+    // Top-level typo.
+    expect(() =>
+      supervisorConfigSchema.parse({ ...validConfig, slotz: [] }),
+    ).toThrow();
+    // Model-level typo (proves nested strictness).
+    expect(() =>
+      supervisorConfigSchema.parse({
+        slots: [
+          {
+            kind: "inference",
+            gpuIndex: 0,
+            models: [{ name: "example-chat", port: 8001, prt: 8002 }],
+          },
+        ],
+      }),
     ).toThrow();
   });
 });
@@ -346,6 +482,17 @@ describe("joinUrl", () => {
   it("preserves repeated base query keys", () => {
     expect(joinUrl("https://host.example?tag=a&tag=b", "/v1/status")).toBe(
       "https://host.example/v1/status?tag=a&tag=b",
+    );
+  });
+
+  it("does not let a protocol-relative path swap the origin", () => {
+    // `//evil.example/x` must stay a path on the base host, never
+    // resolve as a protocol-relative URL to evil.example.
+    expect(joinUrl("https://host.example", "//evil.example/x")).toBe(
+      "https://host.example/evil.example/x",
+    );
+    expect(joinUrl("https://host.example/base", "///evil.example")).toBe(
+      "https://host.example/base/evil.example",
     );
   });
 });

--- a/packages/protocol/src/route-intent.ts
+++ b/packages/protocol/src/route-intent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { storedSlugSchema } from "./enums.js";
+import { slugSchema } from "./enums.js";
 import { httpUrlSchema, modelBindingSchema } from "./fleet.js";
 
 /**
@@ -22,7 +22,7 @@ export type RouteModel = z.infer<typeof routeModelSchema>;
  */
 export const routeTargetSchema = z.object({
   domainId: z.uuid(),
-  domainSlug: storedSlugSchema,
+  domainSlug: slugSchema,
   /** OpenAI-compatible base URL for the domain, null if not yet known. */
   endpointUrl: httpUrlSchema.nullable(),
   /**
@@ -40,7 +40,7 @@ export type RouteTarget = z.infer<typeof routeTargetSchema>;
 
 export const routeIntentSchema = z.object({
   fleetId: z.uuid(),
-  fleetSlug: storedSlugSchema,
+  fleetSlug: slugSchema,
   /**
    * Monotonic revision, bumped on every active-pointer move. Consumers
    * can cache-bust or order updates on it.

--- a/packages/protocol/src/route-intent.ts
+++ b/packages/protocol/src/route-intent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { slugSchema } from "./enums.js";
+import { storedSlugSchema } from "./enums.js";
 import { httpUrlSchema, modelBindingSchema } from "./fleet.js";
 
 /**
@@ -22,7 +22,7 @@ export type RouteModel = z.infer<typeof routeModelSchema>;
  */
 export const routeTargetSchema = z.object({
   domainId: z.uuid(),
-  domainSlug: slugSchema,
+  domainSlug: storedSlugSchema,
   /** OpenAI-compatible base URL for the domain, null if not yet known. */
   endpointUrl: httpUrlSchema.nullable(),
   /**
@@ -40,7 +40,7 @@ export type RouteTarget = z.infer<typeof routeTargetSchema>;
 
 export const routeIntentSchema = z.object({
   fleetId: z.uuid(),
-  fleetSlug: slugSchema,
+  fleetSlug: storedSlugSchema,
   /**
    * Monotonic revision, bumped on every active-pointer move. Consumers
    * can cache-bust or order updates on it.

--- a/packages/protocol/src/supervisor.ts
+++ b/packages/protocol/src/supervisor.ts
@@ -9,7 +9,9 @@ import { slotKindSchema } from "./enums.js";
  * their admin endpoints (sleep/wake) are private, local-only controls
  * that are never exposed beyond the supervisor.
  */
-export const supervisorInferenceModelConfigSchema = z.object({
+// Strict: HARU_SUPERVISOR_CONFIG is operator-authored, so a misspelled
+// key must fail at load time rather than be silently dropped.
+export const supervisorInferenceModelConfigSchema = z.strictObject({
   name: z.string().min(1),
   /** Local port of the vLLM server for this model on 127.0.0.1. */
   port: z.number().int().min(1).max(65_535),
@@ -18,13 +20,13 @@ export type SupervisorInferenceModelConfig = z.infer<
   typeof supervisorInferenceModelConfigSchema
 >;
 
-export const supervisorInferenceSlotConfigSchema = z.object({
+export const supervisorInferenceSlotConfigSchema = z.strictObject({
   kind: z.literal("inference"),
   gpuIndex: z.number().int().nonnegative(),
   models: z.array(supervisorInferenceModelConfigSchema).min(1),
 });
 
-export const supervisorTrainingSlotConfigSchema = z.object({
+export const supervisorTrainingSlotConfigSchema = z.strictObject({
   kind: z.literal("training"),
   gpuIndex: z.number().int().nonnegative(),
   command: z.array(z.string().min(1)).min(1),
@@ -38,7 +40,7 @@ export const supervisorSlotConfigSchema = z.discriminatedUnion("kind", [
 export type SupervisorSlotConfig = z.infer<typeof supervisorSlotConfigSchema>;
 
 export const supervisorConfigSchema = z
-  .object({
+  .strictObject({
     slots: z.array(supervisorSlotConfigSchema).min(1),
   })
   // The supervisor keys training runs by gpuIndex; a duplicate

--- a/packages/protocol/src/supervisor.ts
+++ b/packages/protocol/src/supervisor.ts
@@ -41,6 +41,9 @@ export type SupervisorSlotConfig = z.infer<typeof supervisorSlotConfigSchema>;
 
 export const supervisorConfigSchema = z
   .strictObject({
+    /** Optional pointer to the bundled JSON Schema, so an editor can
+     * validate / autocomplete the config. Ignored by the loader. */
+    $schema: z.string().optional(),
     slots: z.array(supervisorSlotConfigSchema).min(1),
   })
   // The supervisor keys training runs by gpuIndex; a duplicate
@@ -100,8 +103,13 @@ export const supervisorStatusSchema = z.object({
 export type SupervisorStatus = z.infer<typeof supervisorStatusSchema>;
 
 /** POST /v1/vllm/sleep and /v1/vllm/wake body. Omitted gpuIndex means
- * every inference slot on the host. */
-export const vllmTargetRequestSchema = z.object({
+ * every inference slot on the host.
+ *
+ * The supervisor's inbound request bodies are strict: the server is the
+ * only caller and ships from the same repo, so an unknown key is drift
+ * or a typo, not a compatible extension. (Supervisor RESPONSE schemas,
+ * which the server parses, stay lenient - leniency toward a peer.) */
+export const vllmTargetRequestSchema = z.strictObject({
   gpuIndex: z.number().int().nonnegative().optional(),
 });
 export type VllmTargetRequest = z.infer<typeof vllmTargetRequestSchema>;
@@ -113,7 +121,7 @@ export type VllmTargetRequest = z.infer<typeof vllmTargetRequestSchema>;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 /** POST /v1/training/stop body. */
-export const trainingStopRequestSchema = z.object({
+export const trainingStopRequestSchema = z.strictObject({
   graceMs: z.number().int().positive().max(MAX_TIMEOUT_MS).optional(),
 });
 export type TrainingStopRequest = z.infer<typeof trainingStopRequestSchema>;
@@ -132,7 +140,7 @@ export const gpuMemorySchema = z.object({
 export type GpuMemory = z.infer<typeof gpuMemorySchema>;
 
 /** POST /v1/probe body. */
-export const probeRequestSchema = z.object({
+export const probeRequestSchema = z.strictObject({
   prompt: z.string().min(1).default("ping"),
   maxTokens: z.number().int().positive().default(4),
   /**

--- a/packages/protocol/src/url.ts
+++ b/packages/protocol/src/url.ts
@@ -13,11 +13,13 @@
 export function joinUrl(baseUrl: string, path: string): string {
   const base = new URL(baseUrl);
   const prefix = base.pathname.replace(/\/+$/, "");
-  // Collapse any leading slashes to exactly one. A `path` like
-  // `//evil.example/x` would otherwise be parsed as a protocol-relative
-  // URL and swap the base's host/origin. Every caller passes a
+  // Collapse any leading slashes AND backslashes to exactly one forward
+  // slash. A `path` like `//evil.example/x` - or `\\evil.example/x`,
+  // which the WHATWG URL parser normalizes to `//` on http/https - would
+  // otherwise be parsed as protocol-relative and swap the base's
+  // host/origin against an origin-only base. Every caller passes a
   // code-literal path today, so this is defense in depth.
-  const suffix = `/${path.replace(/^\/+/, "")}`;
+  const suffix = `/${path.replace(/^[\\/]+/, "")}`;
   const joined = new URL(`${prefix}${suffix}`, base);
   // Re-apply the base query params that `new URL` dropped. Snapshot the
   // path's OWN keys first so a same-named base param is skipped (path

--- a/packages/protocol/src/url.ts
+++ b/packages/protocol/src/url.ts
@@ -13,7 +13,11 @@
 export function joinUrl(baseUrl: string, path: string): string {
   const base = new URL(baseUrl);
   const prefix = base.pathname.replace(/\/+$/, "");
-  const suffix = path.startsWith("/") ? path : `/${path}`;
+  // Collapse any leading slashes to exactly one. A `path` like
+  // `//evil.example/x` would otherwise be parsed as a protocol-relative
+  // URL and swap the base's host/origin. Every caller passes a
+  // code-literal path today, so this is defense in depth.
+  const suffix = `/${path.replace(/^\/+/, "")}`;
   const joined = new URL(`${prefix}${suffix}`, base);
   // Re-apply the base query params that `new URL` dropped. Snapshot the
   // path's OWN keys first so a same-named base param is skipped (path

--- a/services/haru-server/src/environment.test.ts
+++ b/services/haru-server/src/environment.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { loadServerEnvironment } from "./environment.js";
+
+describe("loadServerEnvironment", () => {
+  const base = { DATABASE_URL: "postgres://localhost/haru" };
+
+  it("treats a blank HARU_RECONCILE_FLEETS as unset (does not shadow the fallback)", () => {
+    expect(
+      loadServerEnvironment({ ...base, HARU_RECONCILE_FLEETS: "" })
+        .HARU_RECONCILE_FLEETS,
+    ).toBeUndefined();
+    expect(
+      loadServerEnvironment({ ...base, HARU_RECONCILE_FLEETS: " ".repeat(3) })
+        .HARU_RECONCILE_FLEETS,
+    ).toBeUndefined();
+  });
+
+  it("treats a blank HARU_DEFAULT_FLEET as unset", () => {
+    expect(
+      loadServerEnvironment({ ...base, HARU_DEFAULT_FLEET: "" })
+        .HARU_DEFAULT_FLEET,
+    ).toBeUndefined();
+  });
+
+  it("trims and keeps a configured value", () => {
+    expect(
+      loadServerEnvironment({ ...base, HARU_RECONCILE_FLEETS: " a, b " })
+        .HARU_RECONCILE_FLEETS,
+    ).toBe("a, b");
+    expect(
+      loadServerEnvironment({ ...base, HARU_DEFAULT_FLEET: "prod" })
+        .HARU_DEFAULT_FLEET,
+    ).toBe("prod");
+  });
+});

--- a/services/haru-server/src/environment.ts
+++ b/services/haru-server/src/environment.ts
@@ -1,5 +1,21 @@
 import { z } from "zod";
 
+/**
+ * An optional string env var where a present-but-blank value (empty or
+ * whitespace-only, e.g. an unexpanded `$VAR` in a manifest) is treated
+ * as unset. Without this, a blank var counts as "present" and shadows a
+ * `??` fallback: a blank HARU_RECONCILE_FLEETS would suppress the
+ * HARU_DEFAULT_FLEET fallback and leave the reconcile loop iterating no
+ * fleets while the interval timer still fires.
+ */
+const blankableStringSchema = z
+  .string()
+  .optional()
+  .transform((value) => {
+    const trimmed = value?.trim();
+    return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+  });
+
 /** Server boot environment. Only main.ts reads this; the app factory
  * takes explicit dependencies so tests never touch process.env. */
 export const serverEnvironmentSchema = z.object({
@@ -7,7 +23,7 @@ export const serverEnvironmentSchema = z.object({
   PORT: z.coerce.number().int().min(1).max(65_535).default(8700),
   HARU_API_TOKEN: z.string().optional(),
   HARU_SUPERVISOR_TOKEN: z.string().optional(),
-  HARU_DEFAULT_FLEET: z.string().optional(),
+  HARU_DEFAULT_FLEET: blankableStringSchema,
   /** TTFB bound for the chat proxy; raise for long non-streaming
    * completions (headers arrive only after full generation). */
   HARU_CHAT_HEADER_TIMEOUT_MS: z.coerce
@@ -40,8 +56,10 @@ export const serverEnvironmentSchema = z.object({
     .positive()
     .max(2_147_483_647)
     .optional(),
-  /** Fleets the background loop reconciles (comma-separated slugs). */
-  HARU_RECONCILE_FLEETS: z.string().optional(),
+  /** Fleets the background loop reconciles (comma-separated slugs). A
+   * blank value is treated as unset so it does not shadow the
+   * HARU_DEFAULT_FLEET fallback in main.ts. */
+  HARU_RECONCILE_FLEETS: blankableStringSchema,
 });
 export type ServerEnvironment = z.infer<typeof serverEnvironmentSchema>;
 

--- a/services/haru-supervisor/src/main.ts
+++ b/services/haru-supervisor/src/main.ts
@@ -15,6 +15,16 @@ const environmentSchema = z.object({
   HARU_SUPERVISOR_CONFIG: z.string().min(1),
 });
 
+// Mirror the server / seed / drizzle entrypoints: load the repo-root
+// .env so a developer's local vars (HARU_SUPERVISOR_CONFIG,
+// HARU_SUPERVISOR_TOKEN) are honored. Production injects env via the
+// orchestrator, where no .env exists and this is a no-op.
+try {
+  process.loadEnvFile("../../.env");
+} catch {
+  // No .env file; rely on the process environment.
+}
+
 const environment = environmentSchema.parse(process.env);
 const config = loadSupervisorConfig(environment.HARU_SUPERVISOR_CONFIG);
 
@@ -111,7 +121,7 @@ const server = serve(
  * the whole group. */
 const SHUTDOWN_TRAINING_GRACE_MS = 30_000;
 
-// Installing a SIGTERM handler suppresses Node's default
+// Installing these handlers suppresses Node's default
 // terminate-on-signal, so the handler must complete the shutdown
 // itself. Trainers MUST be stopped here: they run as detached process
 // groups, so an unstopped run would survive the restart holding GPU
@@ -119,21 +129,37 @@ const SHUTDOWN_TRAINING_GRACE_MS = 30_000;
 // start a second run beside it. beginShutdown also rejects any
 // /v1/training/start still draining through server.close(), so no
 // trainer can spawn after the stop sweep.
-process.on("SIGTERM", () => {
-  beginShutdown(SHUTDOWN_TRAINING_GRACE_MS);
-  // Closing the listener lets the process exit naturally once the
-  // event loop drains; the pending kill timers keep it alive until
-  // every trainer exited or was SIGKILLed.
-  server.close();
-  // Hard stop: a stuck client connection or an unkillable child (D
-  // state after SIGKILL) must not hold the process until the platform
-  // SIGKILLs it. By this point every trainer has had SIGTERM plus the
-  // full grace plus SIGKILL, so nothing orderly remains. unref() so
-  // the timer never keeps an otherwise-drained process alive.
-  const hardStop = setTimeout(() => {
-    console.error("shutdown did not drain in time; exiting");
-    // eslint-disable-next-line n/no-process-exit -- last resort after server.close() stalled
-    process.exit(1);
-  }, SHUTDOWN_TRAINING_GRACE_MS + 10_000);
-  hardStop.unref();
-});
+//
+// Handle SIGINT as well as SIGTERM: production stops via SIGTERM
+// (systemd/k8s), but Ctrl-C under `pnpm dev` / foreground debugging
+// delivers SIGINT, and Node's default SIGINT would terminate WITHOUT
+// running the trainer sweep - orphaning the detached process group on
+// the GPU exactly as the sweep exists to prevent. A mutable field
+// (not a rebindable top-level `let`) makes shutdown idempotent across
+// both signals: a second SIGTERM/SIGINT during teardown must not
+// schedule a second hardStop timer or re-close the listener.
+const shutdownState = { started: false };
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+  process.on(signal, () => {
+    if (shutdownState.started) {
+      return;
+    }
+    shutdownState.started = true;
+    beginShutdown(SHUTDOWN_TRAINING_GRACE_MS);
+    // Closing the listener lets the process exit naturally once the
+    // event loop drains; the pending kill timers keep it alive until
+    // every trainer exited or was SIGKILLed.
+    server.close();
+    // Hard stop: a stuck client connection or an unkillable child (D
+    // state after SIGKILL) must not hold the process until the platform
+    // SIGKILLs it. By this point every trainer has had SIGTERM plus the
+    // full grace plus SIGKILL, so nothing orderly remains. unref() so
+    // the timer never keeps an otherwise-drained process alive.
+    const hardStop = setTimeout(() => {
+      console.error("shutdown did not drain in time; exiting");
+      // eslint-disable-next-line n/no-process-exit -- last resort after server.close() stalled
+      process.exit(1);
+    }, SHUTDOWN_TRAINING_GRACE_MS + 10_000);
+    hardStop.unref();
+  });
+}


### PR DESCRIPTION
Full review of `main`, the fixes it surfaced, three follow-up product improvements, and two adversarial self-review passes (one of which caught a real bug before merge). The product is pre-deployment (no DB), so breaking changes were on the table.

## Review outcome
Two independent review passes (subsystem fan-out + adversarial verification) over `packages/` and `services/` found **no P1/P2 correctness or concurrency defects** — the CAS/reconciler/chat-proxy/supervisor invariants all hold as documented. Everything below is config-hardening, defense-in-depth, or DX.

## What changed

**Hardening (from the review)**
- Operator config zod schemas → `z.strictObject` (fleet layout, policy, placement, slot specs, supervisor config): a misspelled key (e.g. `autoFailver`) is now a config-time error instead of a silently dropped safety setting. Peer-response and the chat passthrough schemas stay lenient.
- `slotSnapshotSchema` enforces `kind === spec.kind` at the read boundary.
- `slugSchema` forbids leading/trailing/consecutive hyphens (valid DNS label); one strict contract on input and read-back.
- `joinUrl` collapses a leading `//` (protocol-relative origin-swap guard).
- Bearer auth accepts RFC 9110 optional whitespace (tab/trailing); constant-time compare unchanged.
- haru-server: a blank `HARU_RECONCILE_FLEETS`/`HARU_DEFAULT_FLEET` is treated as unset so it can't shadow the fallback and leave the reconcile loop iterating no fleets.
- haru-supervisor: handle SIGINT as well as SIGTERM (Ctrl-C under dev would orphan detached VRAM-holding trainers), idempotent shutdown, load repo-root `.env` like the sibling entrypoints.
- SkyServe status scraper skips the NAME column when matching the status token.

**Improvements (pre-deployment)**
- Strict internal API request DTOs (promote/demote, vllm sleep-wake, training-stop, probe): client/server/supervisor ship together, so an unknown field is drift/typo, not a compatible extension. Responses stay loose.
- DB CHECK constraints as defense-in-depth behind the app layer (slug format, `route_revision > 0`, `gpu_index >= 0`) — migration `0002`.
- Bundled JSON Schemas for the operator configs, generated from the zod source of truth (`pnpm schemas:generate`, `io:"input"` so defaulted fields stay optional). Both config schemas accept an optional `$schema`; the example layout points at the bundled schema; a vitest drift test keeps the committed schemas in sync.

**Self-review fix**
- A workflow self-review of this branch caught the JSON Schema generator emitting `io:"output"` (marking `.default()` fields `required`, so the shipped example failed its own schema), plus two format/lint plumbing papercuts. All fixed; a structural test now guards the io mode.

## Verification
`build` 7/7 · `typecheck` 12/12 · `lint` 7/7 · `format:check` clean · **276 tests pass** · db-drift idempotent. Everything runs without GPUs, cloud accounts, or a live database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens config validation and service lifecycle, adds bundled JSON Schemas, and introduces DB CHECK constraints for defense-in-depth. Aligns with eng-925 by rejecting config typos, tightening invariants, and closing edge cases.

- **New Features**
  - Strict validation: operator configs (`fleetLayout`, policy, placement, slot specs, `supervisorConfig`) and internal request DTOs now reject unknown keys; responses remain lenient.
  - Bundled JSON Schemas for operator configs in `packages/protocol/schemas` (generated via `pnpm schemas:generate`, `io: "input"`); `$schema` is accepted and the example layout points to it.
  - Lifecycle and safety: supervisor handles SIGINT with idempotent shutdown and loads repo-root `.env`; enforce `slot.kind === spec.kind`; stricter DNS-label-safe `slug`.
  - Edge cases: `joinUrl` collapses leading slashes and backslashes (origin-swap guard); Bearer auth accepts optional whitespace per RFC 9110; SkyServe status parser skips the NAME column; blank `HARU_RECONCILE_FLEETS`/`HARU_DEFAULT_FLEET` are treated as unset.

- **Migration**
  - Run `pnpm db:migrate` to apply migration `0002` (CHECKs for slug format, `fleets.route_revision > 0`, and `slots.gpu_index >= 0`).

<sup>Written for commit cea781505445130270cccd46c00494665e6d4e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/haru/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generated JSON Schemas for fleet layout and supervisor configuration (including editor-friendly `$schema` support).
  * Added a `schemas:generate` command to regenerate committed schemas.
  * Local supervisor startup now loads a repository `.env` file when present.
* **Bug Fixes**
  * Improved bearer-token parsing.
  * Hardened URL joining to prevent origin/protocol-relative ambiguity.
  * Blank environment variables now correctly behave as unset.
  * Supervisor shutdown now handles both termination and interruption signals reliably.
* **Validation**
  * Unknown fields are now rejected more strictly across operator configs and requests.
  * Slug and numeric fields are enforced with database-level constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->