### PR TITLE
Harden validation & lifecycle (adversarial main-branch review)

### DIFF
--- a/packages/db/src/schema/fleets.ts
+++ b/packages/db/src/schema/fleets.ts
@@ -9,7 +9,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 
-import type { FleetPolicy } from "@haru/protocol";
+import type { FleetPolicyPatch } from "@haru/protocol";
 
 export const fleets = pgTable(
   "fleets",
@@ -27,8 +27,9 @@ export const fleets = pgTable(
     activeDomainId: uuid("active_domain_id"),
     /** Bumped on every active-pointer move; consumers order on it. */
     routeRevision: integer("route_revision").notNull().default(1),
-    /** Partial FleetPolicy; parsed with defaults on read. */
-    policy: jsonb("policy").$type<Partial<FleetPolicy>>().notNull().default({}),
+    /** Operator-provided policy keys only (a partial); the rest resolve
+     * to the CURRENT default on read via resolveFleetPolicy. */
+    policy: jsonb("policy").$type<FleetPolicyPatch>().notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/packages/protocol/schemas/fleet-layout.schema.json
+++ b/packages/protocol/schemas/fleet-layout.schema.json
@@ -25,83 +25,66 @@
       "type": "object",
       "properties": {
         "autoFailover": {
-          "default": false,
           "type": "boolean"
         },
         "heartbeatStaleMs": {
-          "default": 30000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "degradedGraceMs": {
-          "default": 60000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "trainingStopGraceMs": {
-          "default": 30000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "stopTrainingTimeoutMs": {
-          "default": 90000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "verifyGpuTimeoutMs": {
-          "default": 30000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "wakeTimeoutMs": {
-          "default": 120000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "probeTimeoutMs": {
-          "default": 60000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "switchActiveTimeoutMs": {
-          "default": 10000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "sleepTimeoutMs": {
-          "default": 60000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "startTrainingTimeoutMs": {
-          "default": 30000,
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 2147483647
         },
         "probe": {
-          "default": {
-            "prompt": "ping",
-            "maxTokens": 4
-          },
           "type": "object",
           "properties": {
             "prompt": {
-              "default": "ping",
               "type": "string",
               "minLength": 1
             },
             "maxTokens": {
-              "default": 4,
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991

--- a/packages/protocol/src/environment.ts
+++ b/packages/protocol/src/environment.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/**
+ * Environment-variable parsing helpers shared by both services' boot
+ * schemas. They exist because an env var is either absent (`undefined`)
+ * or a string, and a *present-but-blank* string (empty or
+ * whitespace-only, e.g. an unexpanded `${VAR}` left by a manifest
+ * templating step) must be treated as unset rather than as data - which
+ * neither zod's `.optional()`/`.default()` nor `z.coerce.number()` do on
+ * their own.
+ */
+
+/**
+ * An optional string env var where a blank value reads as unset, and a
+ * non-blank value is trimmed. Trimming matters for secrets too: a
+ * trailing newline from a secret file must resolve to the same
+ * credential a `\S+` bearer capture presents, and a whitespace-only
+ * token must not count as "set" (it would open a public bind while being
+ * unmatchable).
+ */
+export const blankableString = z
+  .string()
+  .optional()
+  .transform((value) => {
+    const trimmed = value?.trim();
+    return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+  });
+
+/**
+ * Wrap a numeric env schema so a present-but-blank value is treated as
+ * unset. Without it, `z.coerce.number()` coerces `""` to 0, which then
+ * fails a `.positive()` / `.min()` bound and crashes boot with a
+ * confusing "must be greater than 0" instead of falling back to the
+ * field's default (or staying optional).
+ */
+export function blankableNumber<Schema extends z.ZodType>(schema: Schema) {
+  return z.preprocess(
+    (value) =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    schema,
+  );
+}

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -25,6 +25,8 @@ export const ERROR_CODES = {
   payloadTooLarge: "payload_too_large",
   /** The supervisor received SIGTERM; no new work is accepted. */
   shuttingDown: "shutting_down",
+  /** Unexpected server-side fault (the API's default onError). */
+  internalError: "internal_error",
   /**
    * The chat proxy could not resolve routing for THIS fleet from the
    * state store, and had no usable cached routing for it either: the

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth.js";
 export * from "./chat.js";
 export * from "./enums.js";
+export * from "./environment.js";
 export * from "./errors.js";
 export * from "./exec.js";
 export * from "./http.js";

--- a/packages/protocol/src/layout.ts
+++ b/packages/protocol/src/layout.ts
@@ -7,7 +7,7 @@ import {
   trainingSlotSpecSchema,
 } from "./fleet.js";
 import { placementSpecSchema } from "./placement.js";
-import { fleetPolicySchema } from "./policy.js";
+import { fleetPolicyPatchSchema } from "./policy.js";
 
 /**
  * Declarative fleet layout, used to seed or reconcile a fleet into the
@@ -49,8 +49,11 @@ export const fleetLayoutSchema = z
     displayName: z.string().min(1).optional(),
     /** Slug of the domain that starts active; must name a domain below. */
     activeDomainSlug: slugSchema.optional(),
-    /** Partial policy; unset fields resolve to defaults on read. */
-    policy: fleetPolicySchema.partial().optional(),
+    /** Partial policy; only the operator-provided keys are stored, and
+     * unset fields resolve to the CURRENT default on read (see
+     * fleetPolicyPatchSchema - a plain `.partial()` would bake every
+     * default into the stored value). */
+    policy: fleetPolicyPatchSchema.optional(),
     domains: z.array(domainLayoutSchema).min(1),
   })
   .refine(

--- a/packages/protocol/src/policy.ts
+++ b/packages/protocol/src/policy.ts
@@ -24,8 +24,9 @@ export type ProbePolicy = z.infer<typeof probePolicySchema>;
 /** Storage form of the probe config: like probePolicySchema but WITHOUT
  * the inner defaults, so a `{ probe: { prompt } }` layout patch does not
  * bake in the sibling maxTokens (a plain `.partial()` still fires each
- * field's `.default()`). */
-const probePolicyPatchSchema = z.strictObject({
+ * field's `.default()`). Exported for the drift-guard test that keeps
+ * its key set in lockstep with probePolicySchema. */
+export const probePolicyPatchSchema = z.strictObject({
   prompt: probePromptSchema.optional(),
   maxTokens: probeMaxTokensSchema.optional(),
 });

--- a/packages/protocol/src/policy.ts
+++ b/packages/protocol/src/policy.ts
@@ -9,14 +9,26 @@ import { z } from "zod";
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const timeoutMsSchema = z.number().int().positive().max(MAX_TIMEOUT_MS);
 
+const probePromptSchema = z.string().min(1);
+const probeMaxTokensSchema = z.number().int().positive();
+
 /** Synthetic inference probe configuration. Strict: this is
  * operator-authored config, so a misspelled key must fail at parse
  * time rather than be silently dropped. */
 export const probePolicySchema = z.strictObject({
-  prompt: z.string().min(1).default("ping"),
-  maxTokens: z.number().int().positive().default(4),
+  prompt: probePromptSchema.default("ping"),
+  maxTokens: probeMaxTokensSchema.default(4),
 });
 export type ProbePolicy = z.infer<typeof probePolicySchema>;
+
+/** Storage form of the probe config: like probePolicySchema but WITHOUT
+ * the inner defaults, so a `{ probe: { prompt } }` layout patch does not
+ * bake in the sibling maxTokens (a plain `.partial()` still fires each
+ * field's `.default()`). */
+const probePolicyPatchSchema = z.strictObject({
+  prompt: probePromptSchema.optional(),
+  maxTokens: probeMaxTokensSchema.optional(),
+});
 
 /**
  * Per-fleet operational policy. Stored as jsonb on the fleet row and
@@ -33,9 +45,11 @@ export type ProbePolicy = z.infer<typeof probePolicySchema>;
  * like `autoFailover` at its default. `.partial()` in the layout
  * schema inherits this strictness.
  */
+const autoFailoverSchema = z.boolean();
+
 export const fleetPolicySchema = z.strictObject({
   /** Automatically promote a standby when the active goes stale. */
-  autoFailover: z.boolean().default(false),
+  autoFailover: autoFailoverSchema.default(false),
   /** Active domain heartbeat staleness threshold. */
   heartbeatStaleMs: timeoutMsSchema.default(30_000),
   /**
@@ -64,6 +78,41 @@ export const fleetPolicySchema = z.strictObject({
   probe: probePolicySchema.default({ prompt: "ping", maxTokens: 4 }),
 });
 export type FleetPolicy = z.infer<typeof fleetPolicySchema>;
+
+/**
+ * A partial policy for STORAGE (the layout's `policy` block, persisted
+ * to the fleet's jsonb column). Unlike `fleetPolicySchema.partial()`,
+ * this must NOT bake each field's default into the stored value: Zod's
+ * `.partial()` only wraps a field in `.optional()`, leaving the inner
+ * `.default()` to still fire, so a `{ autoFailover: true }` layout would
+ * persist ALL eleven defaults. Because `resolveFleetPolicy` never
+ * re-defaults a key that is already present, that would freeze the
+ * fleet against any later change to a default (e.g. lowering
+ * `heartbeatStaleMs`), and re-seeding cannot fix it (the fleet insert is
+ * ON CONFLICT DO NOTHING). Storing only the operator-provided keys keeps
+ * the documented contract: unset fields resolve to the CURRENT default
+ * on read. Still strict, so a typo'd key remains a config-time error.
+ *
+ * Keep the key set in lockstep with `fleetPolicySchema` - the drift
+ * guard in protocol.test.ts asserts the two shapes match.
+ */
+export const fleetPolicyPatchSchema = z.strictObject({
+  autoFailover: autoFailoverSchema.optional(),
+  heartbeatStaleMs: timeoutMsSchema.optional(),
+  degradedGraceMs: timeoutMsSchema.optional(),
+  trainingStopGraceMs: timeoutMsSchema.optional(),
+  stopTrainingTimeoutMs: timeoutMsSchema.optional(),
+  verifyGpuTimeoutMs: timeoutMsSchema.optional(),
+  wakeTimeoutMs: timeoutMsSchema.optional(),
+  probeTimeoutMs: timeoutMsSchema.optional(),
+  switchActiveTimeoutMs: timeoutMsSchema.optional(),
+  sleepTimeoutMs: timeoutMsSchema.optional(),
+  startTrainingTimeoutMs: timeoutMsSchema.optional(),
+  // The probe sub-object carries its OWN defaults; use the patch form so
+  // a `{ probe: { prompt } }` patch does not bake in maxTokens.
+  probe: probePolicyPatchSchema.optional(),
+});
+export type FleetPolicyPatch = z.infer<typeof fleetPolicyPatchSchema>;
 
 /** Parse a possibly-partial policy value (e.g. a jsonb column) into a
  * fully defaulted policy. `null`/`undefined` yield all defaults. */

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -17,6 +17,8 @@ import { placementSpecSchema } from "./placement.js";
 import {
   fleetPolicyPatchSchema,
   fleetPolicySchema,
+  probePolicyPatchSchema,
+  probePolicySchema,
   resolveFleetPolicy,
 } from "./policy.js";
 import {
@@ -410,6 +412,13 @@ describe("fleetLayoutSchema", () => {
     // operator-tunable setting would be silently rejected at layout time.
     expect(new Set(Object.keys(fleetPolicyPatchSchema.shape))).toEqual(
       new Set(Object.keys(fleetPolicySchema.shape)),
+    );
+    // ...and the nested probe patch, or a new probe field (e.g. a
+    // temperature) would be silently rejected inside a layout's
+    // `policy.probe` while both top-level shapes still share the `probe`
+    // key and this guard stayed green.
+    expect(new Set(Object.keys(probePolicyPatchSchema.shape))).toEqual(
+      new Set(Object.keys(probePolicySchema.shape)),
     );
   });
 

--- a/packages/protocol/src/protocol.test.ts
+++ b/packages/protocol/src/protocol.test.ts
@@ -14,7 +14,11 @@ import {
 import { fleetLayoutSchema } from "./layout.js";
 import { demoteRequestSchema, promoteRequestSchema } from "./operations.js";
 import { placementSpecSchema } from "./placement.js";
-import { fleetPolicySchema, resolveFleetPolicy } from "./policy.js";
+import {
+  fleetPolicyPatchSchema,
+  fleetPolicySchema,
+  resolveFleetPolicy,
+} from "./policy.js";
 import {
   probeRequestSchema,
   supervisorConfigSchema,
@@ -361,9 +365,9 @@ describe("fleetLayoutSchema", () => {
         ],
       }),
     ).toThrow();
-    // Nested-policy typo: proves `fleetPolicySchema.partial()` keeps the
-    // strictness, so a misspelled safety setting inside a layout's
-    // `policy` is still a config-time error.
+    // Nested-policy typo: proves `fleetPolicyPatchSchema` keeps the full
+    // schema's strictness, so a misspelled safety setting inside a
+    // layout's `policy` is still a config-time error.
     expect(() =>
       fleetLayoutSchema.parse({
         ...validLayout,
@@ -377,6 +381,36 @@ describe("fleetLayoutSchema", () => {
         policy: { autoFailover: true },
       }),
     ).not.toThrow();
+  });
+
+  it("stores only operator-provided policy keys (no baked defaults)", () => {
+    // A plain `.partial()` would fire each field's inner `.default()` and
+    // persist all eleven defaults, freezing the fleet against any later
+    // default change. Only the provided key must survive.
+    const parsed = fleetLayoutSchema.parse({
+      ...validLayout,
+      policy: { autoFailover: true },
+    });
+    expect(parsed.policy).toEqual({ autoFailover: true });
+    // A nested probe patch must not bake in the sibling maxTokens either.
+    const withProbe = fleetLayoutSchema.parse({
+      ...validLayout,
+      policy: { probe: { prompt: "hi" } },
+    });
+    expect(withProbe.policy).toEqual({ probe: { prompt: "hi" } });
+    // An omitted policy stays undefined; resolveFleetPolicy fills current
+    // defaults on read.
+    const noPolicy = fleetLayoutSchema.parse(validLayout);
+    expect(noPolicy.policy).toBeUndefined();
+  });
+
+  it("keeps the policy patch schema key set in lockstep with the full policy", () => {
+    // Drift guard: fleetPolicyPatchSchema is authored by hand, so a field
+    // added to fleetPolicySchema must be added to the patch too, or a new
+    // operator-tunable setting would be silently rejected at layout time.
+    expect(new Set(Object.keys(fleetPolicyPatchSchema.shape))).toEqual(
+      new Set(Object.keys(fleetPolicySchema.shape)),
+    );
   });
 
   it("accepts an optional $schema pointer for editor integration", () => {
@@ -561,6 +595,28 @@ describe("joinUrl", () => {
     expect(joinUrl("https://host.example", String.raw`/\evil.example`)).toBe(
       "https://host.example/evil.example",
     );
+  });
+
+  it("does not let an embedded tab/newline/CR swap the origin", () => {
+    // The WHATWG URL parser STRIPS ASCII tab/LF/CR before parsing the
+    // authority, so a control char could re-form `//` after the leading
+    // slash collapse. joinUrl removes them up front, so these resolve to
+    // a plain path on the base host instead of swapping to evil.example.
+    for (const control of ["\t", "\n", "\r"]) {
+      expect(
+        joinUrl("https://host.example", `${control}//evil.example/x`),
+      ).toBe("https://host.example/evil.example/x");
+      expect(
+        joinUrl("https://host.example", `/${control}/evil.example/x`),
+      ).toBe("https://host.example/evil.example/x");
+    }
+  });
+
+  it("refuses a base whose own pathname would swap the host", () => {
+    // A `//a/` pathname on the base parses as protocol-relative when the
+    // suffix is appended, moving the host to `a`; the origin backstop
+    // catches what the path-side collapse cannot. Fail closed.
+    expect(() => joinUrl("https://host.example//a/", "x")).toThrow(/origin/);
   });
 });
 

--- a/packages/protocol/src/url.ts
+++ b/packages/protocol/src/url.ts
@@ -13,14 +13,32 @@
 export function joinUrl(baseUrl: string, path: string): string {
   const base = new URL(baseUrl);
   const prefix = base.pathname.replace(/\/+$/, "");
+  // The WHATWG URL parser STRIPS ASCII tab (0x09), LF (0x0A) and CR
+  // (0x0D) from a URL string before it parses the authority, so a
+  // `path` like `\t//evil.example/x` or `/\t/evil.example/x` would fuse
+  // its remaining slashes into a `//` protocol-relative reference AFTER
+  // the leading-slash collapse below and swap the base's origin. Remove
+  // them up front so the collapse sees the real structure.
+  const withoutUrlWhitespace = path.replaceAll(/[\t\n\r]/g, "");
   // Collapse any leading slashes AND backslashes to exactly one forward
   // slash. A `path` like `//evil.example/x` - or `\\evil.example/x`,
   // which the WHATWG URL parser normalizes to `//` on http/https - would
   // otherwise be parsed as protocol-relative and swap the base's
   // host/origin against an origin-only base. Every caller passes a
   // code-literal path today, so this is defense in depth.
-  const suffix = `/${path.replace(/^[\\/]+/, "")}`;
+  const suffix = `/${withoutUrlWhitespace.replace(/^[\\/]+/, "")}`;
   const joined = new URL(`${prefix}${suffix}`, base);
+  // Final backstop: joinUrl must NEVER change the origin (it only
+  // appends a path/query onto the base). Anything that still moved the
+  // host - a `//host` pathname on the base itself, or any residual
+  // protocol-relative fusion the collapse missed - is a
+  // misconfiguration or an injection attempt, not a routable URL; fail
+  // closed rather than emit a request to the wrong host.
+  if (joined.origin !== base.origin) {
+    throw new Error(
+      `joinUrl refused to change origin (${base.origin} -> ${joined.origin})`,
+    );
+  }
   // Re-apply the base query params that `new URL` dropped. Snapshot the
   // path's OWN keys first so a same-named base param is skipped (path
   // wins on conflict) while EVERY value the base carries for other keys

--- a/services/haru-server/src/app.ts
+++ b/services/haru-server/src/app.ts
@@ -491,12 +491,15 @@ export function createApp(dependencies: AppDependencies) {
 
   // A client that aborts or truncates its upload before we respond
   // leaves nothing to send a body to. Reading such a request (in the
-  // body-size gate or `c.req.text()`) rejects, which would otherwise
-  // reach Hono's default handler as a misleading 500; answer with a bare
-  // nginx-style 499 instead (the client is already gone). Anything else
-  // is a genuine server fault and keeps the 500.
+  // body-size gate or `c.req.text()`) rejects with the request signal
+  // already aborted (@hono/node-server ties it to the socket), which
+  // would otherwise reach Hono's default handler as a misleading 500;
+  // answer with a bare nginx-style 499 instead. Still log it: a genuine
+  // server fault that merely coincides with a client disconnect must not
+  // vanish. Anything with a live client is a real 500.
   app.onError((error, c) => {
     if (c.req.raw.signal.aborted) {
+      console.error("request aborted by the client:", error);
       return new Response(null, { status: 499 });
     }
     console.error("unhandled request error:", error);
@@ -682,17 +685,12 @@ export function createApp(dependencies: AppDependencies) {
       }
 
       // Keep the raw text so unknown fields forward byte-identically;
-      // parse only to extract the model name. Read OUTSIDE the JSON
-      // try/catch below so a failed body read is not mislabelled as a
-      // 400 "invalid JSON": an inbound stream can only fail because the
-      // client aborted or truncated the upload, which is a bare 499 (the
-      // client is gone and never sees any response) - not a server 500.
-      let bodyText: string;
-      try {
-        bodyText = await c.req.text();
-      } catch {
-        return new Response(null, { status: 499 });
-      }
+      // parse only to extract the model name. A failed read here means
+      // the client aborted/truncated the upload (the body-size gate above
+      // has already buffered it, so this only rejects on a live abort);
+      // the request signal is aborted, so app.onError maps it to a bare
+      // 499, never the JSON-parse 400 below or a 500.
+      const bodyText = await c.req.text();
       let model: string;
       try {
         model = chatCompletionRequestSchema.parse(JSON.parse(bodyText)).model;

--- a/services/haru-server/src/app.ts
+++ b/services/haru-server/src/app.ts
@@ -94,6 +94,29 @@ type SnapshotLookup =
 /** Marks a chat response served from a stale (fail-open) snapshot. */
 const STALE_ROUTING_HEADER = "x-haru-routing";
 
+/**
+ * Body cap for the control POSTs (promote/demote). They carry a tiny
+ * JSON object ({ targetDomainId }), but like the chat path they buffer
+ * the whole body before validating it, so an authenticated caller could
+ * otherwise stream an unbounded body straight into memory. 16 KiB is
+ * generous for a UUID payload; the chat path keeps its own, larger,
+ * configurable cap.
+ */
+const CONTROL_MAX_BODY_BYTES = 16 * 1024;
+
+/** Shared 413 gate for the control POSTs, mirroring the chat path. */
+const controlBodyLimit = bodyLimit({
+  maxSize: CONTROL_MAX_BODY_BYTES,
+  onError: (c) =>
+    c.json(
+      errorBody(
+        "payload_too_large",
+        `request body exceeds the ${String(CONTROL_MAX_BODY_BYTES)}-byte limit`,
+      ),
+      413,
+    ),
+});
+
 /** Lowercase a UUID-shaped reference. Licensed ONLY for uuid-ID identity:
  * the database accepts a uuid in any case and returns the lowercase id the
  * fail-open cache is keyed by. Slug and alias identity is case-SENSITIVE
@@ -466,6 +489,20 @@ export function createApp(dependencies: AppDependencies) {
 
   const app = new Hono();
 
+  // A client that aborts or truncates its upload before we respond
+  // leaves nothing to send a body to. Reading such a request (in the
+  // body-size gate or `c.req.text()`) rejects, which would otherwise
+  // reach Hono's default handler as a misleading 500; answer with a bare
+  // nginx-style 499 instead (the client is already gone). Anything else
+  // is a genuine server fault and keeps the 500.
+  app.onError((error, c) => {
+    if (c.req.raw.signal.aborted) {
+      return new Response(null, { status: 499 });
+    }
+    console.error("unhandled request error:", error);
+    return c.json(errorBody("internal_error", "internal server error"), 500);
+  });
+
   app.get("/healthz", (c) => c.json({ ok: true }));
 
   app.use("/v1/*", bearerAuth(config.apiToken));
@@ -565,7 +602,7 @@ export function createApp(dependencies: AppDependencies) {
     };
   }
 
-  app.post("/v1/fleets/:fleetId/promote", async (c) => {
+  app.post("/v1/fleets/:fleetId/promote", controlBodyLimit, async (c) => {
     const body: unknown = await readJsonBody(c.req, null);
     const parsed = promoteRequestSchema.safeParse(body);
     if (!parsed.success) {
@@ -579,7 +616,7 @@ export function createApp(dependencies: AppDependencies) {
     return c.json(result.body as Record<string, unknown>, result.status);
   });
 
-  app.post("/v1/fleets/:fleetId/demote", async (c) => {
+  app.post("/v1/fleets/:fleetId/demote", controlBodyLimit, async (c) => {
     const body: unknown = await readJsonBody(c.req, null);
     const parsed = demoteRequestSchema.safeParse(body);
     if (!parsed.success) {
@@ -645,8 +682,17 @@ export function createApp(dependencies: AppDependencies) {
       }
 
       // Keep the raw text so unknown fields forward byte-identically;
-      // parse only to extract the model name.
-      const bodyText = await c.req.text();
+      // parse only to extract the model name. Read OUTSIDE the JSON
+      // try/catch below so a failed body read is not mislabelled as a
+      // 400 "invalid JSON": an inbound stream can only fail because the
+      // client aborted or truncated the upload, which is a bare 499 (the
+      // client is gone and never sees any response) - not a server 500.
+      let bodyText: string;
+      try {
+        bodyText = await c.req.text();
+      } catch {
+        return new Response(null, { status: 499 });
+      }
       let model: string;
       try {
         model = chatCompletionRequestSchema.parse(JSON.parse(bodyText)).model;

--- a/services/haru-server/src/chat-proxy.ts
+++ b/services/haru-server/src/chat-proxy.ts
@@ -42,11 +42,15 @@ export async function proxyChatCompletion(
   headerTimeoutMs: number,
   clientSignal?: AbortSignal,
 ): Promise<ChatProxyResult> {
-  // joinUrl preserves any path prefix on servingUrl (deployments
-  // behind path-routing gateways); `new URL("/x", base)` would drop it.
-  const url = joinUrl(servingUrl, "/v1/chat/completions");
   let upstream: Response;
   try {
+    // joinUrl preserves any path prefix on servingUrl (deployments
+    // behind path-routing gateways); `new URL("/x", base)` would drop
+    // it. Built INSIDE the try so its origin-swap guard throwing on a
+    // misconfigured servingUrl (a `//host` pathname) folds into the same
+    // 502 upstream_unreachable the other supervisor callers produce,
+    // never an opaque 500.
+    const url = joinUrl(servingUrl, "/v1/chat/completions");
     upstream = await fetchWithTimeout(
       fetchFunction,
       url,

--- a/services/haru-server/src/chat.test.ts
+++ b/services/haru-server/src/chat.test.ts
@@ -108,6 +108,34 @@ describe("POST /v1/chat/completions", () => {
     expect(chatCalls).toHaveLength(0);
   });
 
+  it("returns a bare 499 when the client aborts during the body upload", async () => {
+    const chatCalls: FakeUpstreamCall[] = [];
+    const app = chatApp({ chatCalls });
+    // Model a client that disconnected mid-upload: the request signal is
+    // aborted and reading the body stream rejects. That must surface as a
+    // bare 499 (the client is gone), never a 500 from Hono's default
+    // error handler.
+    const abort = new AbortController();
+    abort.abort();
+    const body = new ReadableStream({
+      pull(controller) {
+        controller.error(new Error("client disconnected"));
+      },
+    });
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-haru-fleet": "default",
+      },
+      body,
+      duplex: "half",
+      signal: abort.signal,
+    } as RequestInit & { duplex: "half" });
+    expect(response.status).toBe(499);
+    expect(chatCalls).toHaveLength(0);
+  });
+
   it("falls back to the configured default fleet", async () => {
     const chatCalls: FakeUpstreamCall[] = [];
     const app = chatApp({ chatCalls, config: { defaultFleet: "default" } });

--- a/services/haru-server/src/environment.test.ts
+++ b/services/haru-server/src/environment.test.ts
@@ -33,4 +33,46 @@ describe("loadServerEnvironment", () => {
         .HARU_DEFAULT_FLEET,
     ).toBe("prod");
   });
+
+  it("treats a blank numeric var as unset instead of crashing on coerced 0", () => {
+    // z.coerce.number() turns "" into 0, which fails .min(1)/.positive();
+    // a blank var must fall back to the default (PORT) or stay optional.
+    expect(loadServerEnvironment({ ...base, PORT: "" }).PORT).toBe(8700);
+    expect(loadServerEnvironment({ ...base, PORT: " ".repeat(3) }).PORT).toBe(
+      8700,
+    );
+    expect(
+      loadServerEnvironment({ ...base, HARU_CHAT_HEADER_TIMEOUT_MS: "" })
+        .HARU_CHAT_HEADER_TIMEOUT_MS,
+    ).toBeUndefined();
+    expect(
+      loadServerEnvironment({
+        ...base,
+        HARU_CHAT_MAX_BODY_BYTES: " ".repeat(2),
+      }).HARU_CHAT_MAX_BODY_BYTES,
+    ).toBeUndefined();
+  });
+
+  it("still parses a real numeric value", () => {
+    expect(loadServerEnvironment({ ...base, PORT: "9000" }).PORT).toBe(9000);
+  });
+
+  it("trims and blank-normalises the bearer tokens", () => {
+    // A whitespace-only token must read as unset (so the surface stays
+    // loopback-bound) rather than a set-but-unmatchable token that binds
+    // publicly; a trailing newline (common from a secret file) must
+    // resolve to the same credential a `\\S+` bearer capture presents.
+    expect(
+      loadServerEnvironment({ ...base, HARU_API_TOKEN: " ".repeat(3) })
+        .HARU_API_TOKEN,
+    ).toBeUndefined();
+    expect(
+      loadServerEnvironment({ ...base, HARU_API_TOKEN: "s3cret\n" })
+        .HARU_API_TOKEN,
+    ).toBe("s3cret");
+    expect(
+      loadServerEnvironment({ ...base, HARU_SUPERVISOR_TOKEN: "\ttok\t" })
+        .HARU_SUPERVISOR_TOKEN,
+    ).toBe("tok");
+  });
 });

--- a/services/haru-server/src/environment.ts
+++ b/services/haru-server/src/environment.ts
@@ -16,46 +16,57 @@ const blankableStringSchema = z
     return trimmed === undefined || trimmed === "" ? undefined : trimmed;
   });
 
+/**
+ * Wrap a numeric env schema so a present-but-blank value (empty or
+ * whitespace-only, e.g. an unexpanded `${VAR}` in a manifest) is treated
+ * as unset. Without this, `z.coerce.number()` coerces `""` to 0, which
+ * then fails the `.positive()` / `.min(1)` bound and crashes boot with a
+ * confusing "must be greater than 0" instead of falling back to the
+ * field's default (or staying optional).
+ */
+function blankableNumber<Schema extends z.ZodType>(schema: Schema) {
+  return z.preprocess(
+    (value) =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    schema,
+  );
+}
+
 /** Server boot environment. Only main.ts reads this; the app factory
  * takes explicit dependencies so tests never touch process.env. */
 export const serverEnvironmentSchema = z.object({
   DATABASE_URL: z.string().min(1),
-  PORT: z.coerce.number().int().min(1).max(65_535).default(8700),
-  HARU_API_TOKEN: z.string().optional(),
-  HARU_SUPERVISOR_TOKEN: z.string().optional(),
+  PORT: blankableNumber(
+    z.coerce.number().int().min(1).max(65_535).default(8700),
+  ),
+  // Bearer tokens are trimmed and blank-normalised: a whitespace-only or
+  // trailing-newline value (common from a secret file) must not count as
+  // "set" - it would bind the surface publicly while `\S+`-captured
+  // credentials could never match it - and a `secret\n` must resolve to
+  // the same `secret` the presented credential carries.
+  HARU_API_TOKEN: blankableStringSchema,
+  HARU_SUPERVISOR_TOKEN: blankableStringSchema,
   HARU_DEFAULT_FLEET: blankableStringSchema,
   /** TTFB bound for the chat proxy; raise for long non-streaming
    * completions (headers arrive only after full generation). */
-  HARU_CHAT_HEADER_TIMEOUT_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .max(2_147_483_647)
-    .optional(),
+  HARU_CHAT_HEADER_TIMEOUT_MS: blankableNumber(
+    z.coerce.number().int().positive().max(2_147_483_647).optional(),
+  ),
   /** Fleet snapshot cache TTL for the chat hot path (default 2000).
    * Pointer moves surface immediately regardless (per-request route
    * revision check); this only bounds slot-state staleness. */
-  HARU_SNAPSHOT_CACHE_TTL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .max(2_147_483_647)
-    .optional(),
+  HARU_SNAPSHOT_CACHE_TTL_MS: blankableNumber(
+    z.coerce.number().int().positive().max(2_147_483_647).optional(),
+  ),
   /** Max chat request body size in bytes (413 above it; default 32
    * MiB). Raise for very large multimodal or long-context payloads. */
-  HARU_CHAT_MAX_BODY_BYTES: z.coerce
-    .number()
-    .int()
-    .positive()
-    .max(2_147_483_647)
-    .optional(),
+  HARU_CHAT_MAX_BODY_BYTES: blankableNumber(
+    z.coerce.number().int().positive().max(2_147_483_647).optional(),
+  ),
   /** Reconcile loop interval; unset disables the background loop. */
-  HARU_RECONCILE_INTERVAL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .max(2_147_483_647)
-    .optional(),
+  HARU_RECONCILE_INTERVAL_MS: blankableNumber(
+    z.coerce.number().int().positive().max(2_147_483_647).optional(),
+  ),
   /** Fleets the background loop reconciles (comma-separated slugs). A
    * blank value is treated as unset so it does not shadow the
    * HARU_DEFAULT_FLEET fallback in main.ts. */

--- a/services/haru-server/src/environment.ts
+++ b/services/haru-server/src/environment.ts
@@ -1,39 +1,13 @@
+import { blankableNumber, blankableString } from "@haru/protocol";
 import { z } from "zod";
 
-/**
- * An optional string env var where a present-but-blank value (empty or
- * whitespace-only, e.g. an unexpanded `$VAR` in a manifest) is treated
- * as unset. Without this, a blank var counts as "present" and shadows a
- * `??` fallback: a blank HARU_RECONCILE_FLEETS would suppress the
- * HARU_DEFAULT_FLEET fallback and leave the reconcile loop iterating no
- * fleets while the interval timer still fires.
- */
-const blankableStringSchema = z
-  .string()
-  .optional()
-  .transform((value) => {
-    const trimmed = value?.trim();
-    return trimmed === undefined || trimmed === "" ? undefined : trimmed;
-  });
-
-/**
- * Wrap a numeric env schema so a present-but-blank value (empty or
- * whitespace-only, e.g. an unexpanded `${VAR}` in a manifest) is treated
- * as unset. Without this, `z.coerce.number()` coerces `""` to 0, which
- * then fails the `.positive()` / `.min(1)` bound and crashes boot with a
- * confusing "must be greater than 0" instead of falling back to the
- * field's default (or staying optional).
- */
-function blankableNumber<Schema extends z.ZodType>(schema: Schema) {
-  return z.preprocess(
-    (value) =>
-      typeof value === "string" && value.trim() === "" ? undefined : value,
-    schema,
-  );
-}
-
 /** Server boot environment. Only main.ts reads this; the app factory
- * takes explicit dependencies so tests never touch process.env. */
+ * takes explicit dependencies so tests never touch process.env.
+ *
+ * `blankableString`/`blankableNumber` (from @haru/protocol) treat a
+ * present-but-blank var as unset: a blank HARU_RECONCILE_FLEETS must not
+ * shadow the HARU_DEFAULT_FLEET `??` fallback in main.ts, and a blank
+ * numeric var must fall back to its default rather than coerce to 0. */
 export const serverEnvironmentSchema = z.object({
   DATABASE_URL: z.string().min(1),
   PORT: blankableNumber(
@@ -44,9 +18,9 @@ export const serverEnvironmentSchema = z.object({
   // "set" - it would bind the surface publicly while `\S+`-captured
   // credentials could never match it - and a `secret\n` must resolve to
   // the same `secret` the presented credential carries.
-  HARU_API_TOKEN: blankableStringSchema,
-  HARU_SUPERVISOR_TOKEN: blankableStringSchema,
-  HARU_DEFAULT_FLEET: blankableStringSchema,
+  HARU_API_TOKEN: blankableString,
+  HARU_SUPERVISOR_TOKEN: blankableString,
+  HARU_DEFAULT_FLEET: blankableString,
   /** TTFB bound for the chat proxy; raise for long non-streaming
    * completions (headers arrive only after full generation). */
   HARU_CHAT_HEADER_TIMEOUT_MS: blankableNumber(
@@ -70,7 +44,7 @@ export const serverEnvironmentSchema = z.object({
   /** Fleets the background loop reconciles (comma-separated slugs). A
    * blank value is treated as unset so it does not shadow the
    * HARU_DEFAULT_FLEET fallback in main.ts. */
-  HARU_RECONCILE_FLEETS: blankableStringSchema,
+  HARU_RECONCILE_FLEETS: blankableString,
 });
 export type ServerEnvironment = z.infer<typeof serverEnvironmentSchema>;
 

--- a/services/haru-server/src/main.ts
+++ b/services/haru-server/src/main.ts
@@ -15,8 +15,9 @@ try {
 const environment = loadServerEnvironment(process.env);
 const database = createDatabase(environment.DATABASE_URL);
 
-const isAuthenticated =
-  environment.HARU_API_TOKEN !== undefined && environment.HARU_API_TOKEN !== "";
+// blankableString already maps a blank/whitespace token to undefined,
+// so a defined value is a real, non-empty token.
+const isAuthenticated = environment.HARU_API_TOKEN !== undefined;
 if (!isAuthenticated) {
   console.warn(
     "HARU_API_TOKEN is not set: the API is UNAUTHENTICATED and will " +

--- a/services/haru-server/src/main.ts
+++ b/services/haru-server/src/main.ts
@@ -15,8 +15,9 @@ try {
 const environment = loadServerEnvironment(process.env);
 const database = createDatabase(environment.DATABASE_URL);
 
-// blankableString already maps a blank/whitespace token to undefined,
-// so a defined value is a real, non-empty token.
+// environment.ts parses HARU_API_TOKEN with blankableString, which maps
+// a blank/whitespace value to undefined, so a defined value here is
+// already a real, non-empty token.
 const isAuthenticated = environment.HARU_API_TOKEN !== undefined;
 if (!isAuthenticated) {
   console.warn(

--- a/services/haru-server/src/promotion-flow.test.ts
+++ b/services/haru-server/src/promotion-flow.test.ts
@@ -90,6 +90,24 @@ async function reconcileUntilSettled(
   return last;
 }
 
+describe("control-route body limit", () => {
+  it("rejects an oversized promote body with 413 before validating it", async () => {
+    await seed();
+    const app = makeApp();
+    // Well over the 16 KiB control cap; must be refused up front rather
+    // than buffered into memory ahead of schema validation.
+    const huge = JSON.stringify({ targetDomainId: "x".repeat(64 * 1024) });
+    const response = await app.request("/v1/fleets/default/promote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: huge,
+    });
+    expect(response.status).toBe(413);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("payload_too_large");
+  });
+});
+
 describe("full promotion flow", () => {
   it("promotes the standby through every step and flips routing", async () => {
     await seed();

--- a/services/haru-supervisor/src/environment.test.ts
+++ b/services/haru-supervisor/src/environment.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { loadSupervisorEnvironment } from "./environment.js";
+
+describe("loadSupervisorEnvironment", () => {
+  const base = { HARU_SUPERVISOR_CONFIG: "/etc/haru/supervisor.json" };
+
+  it("treats a blank PORT as unset and uses the default", () => {
+    expect(loadSupervisorEnvironment({ ...base, PORT: "" }).PORT).toBe(8701);
+    expect(
+      loadSupervisorEnvironment({ ...base, PORT: " ".repeat(3) }).PORT,
+    ).toBe(8701);
+    expect(loadSupervisorEnvironment({ ...base, PORT: "9100" }).PORT).toBe(
+      9100,
+    );
+  });
+
+  it("rejects an out-of-range PORT instead of coercing a blank to 0", () => {
+    expect(() => loadSupervisorEnvironment({ ...base, PORT: "0" })).toThrow();
+    expect(() => loadSupervisorEnvironment({ ...base, PORT: "-1" })).toThrow();
+  });
+
+  it("trims and blank-normalises HARU_SUPERVISOR_TOKEN", () => {
+    // A whitespace-only token must read as unset (so the control plane
+    // stays loopback-bound) rather than a set-but-unmatchable token that
+    // binds publicly; a trailing newline (common from a secret file) must
+    // resolve to the same credential the server presents after its trim.
+    expect(
+      loadSupervisorEnvironment({
+        ...base,
+        HARU_SUPERVISOR_TOKEN: " ".repeat(3),
+      }).HARU_SUPERVISOR_TOKEN,
+    ).toBeUndefined();
+    expect(
+      loadSupervisorEnvironment({ ...base, HARU_SUPERVISOR_TOKEN: "s3cret\n" })
+        .HARU_SUPERVISOR_TOKEN,
+    ).toBe("s3cret");
+    expect(
+      loadSupervisorEnvironment({ ...base, HARU_SUPERVISOR_TOKEN: "\ttok\t" })
+        .HARU_SUPERVISOR_TOKEN,
+    ).toBe("tok");
+  });
+
+  it("requires HARU_SUPERVISOR_CONFIG", () => {
+    expect(() => loadSupervisorEnvironment({})).toThrow();
+  });
+});

--- a/services/haru-supervisor/src/environment.ts
+++ b/services/haru-supervisor/src/environment.ts
@@ -1,0 +1,25 @@
+import { blankableNumber, blankableString } from "@haru/protocol";
+import { z } from "zod";
+
+/** Supervisor boot environment. Only main.ts reads it at runtime;
+ * extracted into this pure module (no import-time side effects) so the
+ * blank/trim normalisation can be unit-tested without main.ts's
+ * serve()/signal-handler setup. */
+export const supervisorEnvironmentSchema = z.object({
+  PORT: blankableNumber(
+    z.coerce.number().int().min(1).max(65_535).default(8701),
+  ),
+  // Trimmed and blank-normalised: a whitespace-only token must not count
+  // as "set" (it would bind the control plane publicly while no `\S+`
+  // credential could match it), and a `secret\n` from a secret file must
+  // resolve to the same `secret` the SERVER sends after its own trim.
+  HARU_SUPERVISOR_TOKEN: blankableString,
+  HARU_SUPERVISOR_CONFIG: z.string().min(1),
+});
+export type SupervisorEnvironment = z.infer<typeof supervisorEnvironmentSchema>;
+
+export function loadSupervisorEnvironment(
+  environment: NodeJS.ProcessEnv,
+): SupervisorEnvironment {
+  return supervisorEnvironmentSchema.parse(environment);
+}

--- a/services/haru-supervisor/src/main.ts
+++ b/services/haru-supervisor/src/main.ts
@@ -22,8 +22,9 @@ try {
 const environment = loadSupervisorEnvironment(process.env);
 const config = loadSupervisorConfig(environment.HARU_SUPERVISOR_CONFIG);
 
-// blankableString already maps a blank/whitespace token to undefined,
-// so a defined value is a real, non-empty token.
+// environment.ts parses HARU_SUPERVISOR_TOKEN with blankableString,
+// which maps a blank/whitespace value to undefined, so a defined value
+// here is already a real, non-empty token.
 const isAuthenticated = environment.HARU_SUPERVISOR_TOKEN !== undefined;
 if (!isAuthenticated) {
   console.warn(

--- a/services/haru-supervisor/src/main.ts
+++ b/services/haru-supervisor/src/main.ts
@@ -9,9 +9,35 @@ import { loadSupervisorConfig } from "./config.js";
 
 import type { SpawnFunction } from "./training.js";
 
+// Treat a present-but-blank numeric var (empty or whitespace-only, e.g.
+// an unexpanded `${VAR}`) as unset: z.coerce.number() would turn "" into
+// 0 and fail .min(1), crashing boot instead of using the default.
+function blankableNumber<Schema extends z.ZodType>(schema: Schema) {
+  return z.preprocess(
+    (value) =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    schema,
+  );
+}
+
+// Trim and blank-normalise the bearer token: a whitespace-only or
+// trailing-newline value (common from a secret file) must not count as
+// "set" (it would bind the control plane publicly while no presented
+// `\S+` credential could ever match it), and `secret\n` must resolve to
+// the same `secret` the SERVER sends after its own trim.
+const blankableTokenSchema = z
+  .string()
+  .optional()
+  .transform((value) => {
+    const trimmed = value?.trim();
+    return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+  });
+
 const environmentSchema = z.object({
-  PORT: z.coerce.number().int().min(1).max(65_535).default(8701),
-  HARU_SUPERVISOR_TOKEN: z.string().optional(),
+  PORT: blankableNumber(
+    z.coerce.number().int().min(1).max(65_535).default(8701),
+  ),
+  HARU_SUPERVISOR_TOKEN: blankableTokenSchema,
   HARU_SUPERVISOR_CONFIG: z.string().min(1),
 });
 

--- a/services/haru-supervisor/src/main.ts
+++ b/services/haru-supervisor/src/main.ts
@@ -2,44 +2,12 @@ import { spawn } from "node:child_process";
 
 import { defaultExec, type ExecFunction } from "@haru/protocol";
 import { serve } from "@hono/node-server";
-import { z } from "zod";
 
 import { createSupervisorApp } from "./app.js";
 import { loadSupervisorConfig } from "./config.js";
+import { loadSupervisorEnvironment } from "./environment.js";
 
 import type { SpawnFunction } from "./training.js";
-
-// Treat a present-but-blank numeric var (empty or whitespace-only, e.g.
-// an unexpanded `${VAR}`) as unset: z.coerce.number() would turn "" into
-// 0 and fail .min(1), crashing boot instead of using the default.
-function blankableNumber<Schema extends z.ZodType>(schema: Schema) {
-  return z.preprocess(
-    (value) =>
-      typeof value === "string" && value.trim() === "" ? undefined : value,
-    schema,
-  );
-}
-
-// Trim and blank-normalise the bearer token: a whitespace-only or
-// trailing-newline value (common from a secret file) must not count as
-// "set" (it would bind the control plane publicly while no presented
-// `\S+` credential could ever match it), and `secret\n` must resolve to
-// the same `secret` the SERVER sends after its own trim.
-const blankableTokenSchema = z
-  .string()
-  .optional()
-  .transform((value) => {
-    const trimmed = value?.trim();
-    return trimmed === undefined || trimmed === "" ? undefined : trimmed;
-  });
-
-const environmentSchema = z.object({
-  PORT: blankableNumber(
-    z.coerce.number().int().min(1).max(65_535).default(8701),
-  ),
-  HARU_SUPERVISOR_TOKEN: blankableTokenSchema,
-  HARU_SUPERVISOR_CONFIG: z.string().min(1),
-});
 
 // Mirror the server / seed / drizzle entrypoints: load the repo-root
 // .env so a developer's local vars (HARU_SUPERVISOR_CONFIG,
@@ -51,7 +19,7 @@ try {
   // No .env file; rely on the process environment.
 }
 
-const environment = environmentSchema.parse(process.env);
+const environment = loadSupervisorEnvironment(process.env);
 const config = loadSupervisorConfig(environment.HARU_SUPERVISOR_CONFIG);
 
 const isAuthenticated =

--- a/services/haru-supervisor/src/main.ts
+++ b/services/haru-supervisor/src/main.ts
@@ -22,9 +22,9 @@ try {
 const environment = loadSupervisorEnvironment(process.env);
 const config = loadSupervisorConfig(environment.HARU_SUPERVISOR_CONFIG);
 
-const isAuthenticated =
-  environment.HARU_SUPERVISOR_TOKEN !== undefined &&
-  environment.HARU_SUPERVISOR_TOKEN !== "";
+// blankableString already maps a blank/whitespace token to undefined,
+// so a defined value is a real, non-empty token.
+const isAuthenticated = environment.HARU_SUPERVISOR_TOKEN !== undefined;
 if (!isAuthenticated) {
   console.warn(
     "HARU_SUPERVISOR_TOKEN is not set: the control API is UNAUTHENTICATED " +


### PR DESCRIPTION
## Summary

Fixes the findings from a full adversarial review of `main` (multi-lens finders → 3-verifier adversarial panel → synthesis), plus the follow-ups from an adversarial self-review of the fix diff. All items are defense-in-depth / robustness; **no behavioural change on valid input**, and the concurrency/routing invariants in `AGENTS.md` are untouched.

Two commits:
- `Harden validation & lifecycle` — the six confirmed findings.
- `Address self-review follow-ups` — six low-severity test/consistency/observability gaps the self-review surfaced.

## Findings fixed

| # | Fix | Area |
|---|-----|------|
| 1 | **joinUrl origin-swap**: strip ASCII TAB/LF/CR from the path (the WHATWG parser drops them before authority parsing and could re-form a `//` origin swap after the leading-slash collapse) + assert the origin never changes as a final backstop (also catches a `//host` base pathname). | `packages/protocol/src/url.ts` |
| 2 | **Fleet policy default-baking**: `.partial()` still fires each field's `.default()`, so a partial layout policy baked all eleven defaults into jsonb and froze the fleet against later default changes. New `fleetPolicyPatchSchema` (+ nested probe patch) stores only operator-provided keys; `resolveFleetPolicy` fills the *current* default on read. Drift-guard test keeps the shapes in lockstep. | `packages/protocol/src/policy.ts`, `layout.ts`, `packages/db/src/schema/fleets.ts` |
| 3 | **Control-route bodyLimit**: 16 KiB cap on `promote`/`demote` so an authenticated caller can't stream an unbounded body into memory ahead of validation (mirrors the chat cap). | `services/haru-server/src/app.ts` |
| 4 | **Chat body read → 499, not 500**: `app.onError` maps a client abort/truncation (aborted request signal) to a bare 499 instead of a misleading 500. | `services/haru-server/src/app.ts` |
| 5 | **Numeric env blank crash**: treat a present-but-blank var as unset so a blank `PORT` falls back to its default instead of coercing `""` → 0 and crash-looping on the `.positive()`/`.min(1)` bound. | `services/haru-server/src/environment.ts` |
| 6 | **Bearer token trim (both services)**: whitespace-only/trailing-newline tokens are trimmed & blank-normalised, so a blank token no longer binds the surface publicly while being unmatchable, and a `secret\n` from a secret file resolves to `secret`. | `environment.ts`, supervisor `environment.ts` |

## Self-review follow-ups

- chat-proxy builds `joinUrl` inside the `try` so an origin-swap throw folds into `502 upstream_unreachable` like the other supervisor callers.
- Removed the now-dead `c.req.text()` try/catch (the body-size gate already buffers; `onError` handles the abort precisely); `onError` now also logs the aborted-client branch.
- Nested `probePolicyPatchSchema` drift guard added.
- Hoisted `blankableString`/`blankableNumber` into `@haru/protocol`; extracted the supervisor boot env into a side-effect-free `environment.ts` with `loadSupervisorEnvironment` + tests (previously untestable).

## Verification

- **Tests**: all 12 packages green — protocol 73, core 52, supervisor 35, db 44, server 99, drivers 13. New regression tests: joinUrl control-char, policy no-baked-defaults + drift guard, env blank/token-trim (both services), promote 413, chat abort 499.
- `pnpm typecheck` 12/12, `pnpm lint` clean, `pnpm format:check` clean.
- JSON Schema (`schemas:generate`) and Drizzle (`db:generate`) drift gates clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens validation and lifecycle paths to prevent origin swaps, frozen policy defaults, unbounded request bodies, and misleading 500s. No behavior change on valid input.

- **Bug Fixes**
  - URL joining: strip TAB/LF/CR and enforce origin unchanged to block protocol-relative swaps and misconfigured bases (`joinUrl`).
  - Fleet policy: store only operator-supplied keys via `fleetPolicyPatchSchema`; defaults resolve on read via `resolveFleetPolicy`; DB column now typed as `FleetPolicyPatch`.
  - Control routes: add a 16 KiB body limit for promote/demote; return 413 on overflow.
  - Chat handler: client-aborted uploads return 499 via `app.onError`; improved logging; standardized 500s; removed dead try/catch.
  - Environment: blank numerics act as unset (avoid "" → 0 boot crashes); bearer tokens trimmed and blank-normalized in both services.
  - Chat proxy: build `joinUrl` inside the try so origin-guard errors surface as 502 upstream_unreachable.

- **Refactors**
  - Hoisted `blankableString` and `blankableNumber` to `@haru/protocol`; server and supervisor use them.
  - Extracted `loadSupervisorEnvironment` to a side-effect-free module with tests.
  - Added drift guards to keep policy patch schemas in lockstep with full policy shapes; layout uses `fleetPolicyPatchSchema`.
  - Simplified token checks in both services’ boot to rely on `blankableString` normalization; clarified boot comments to reference `environment.ts`.

<sup>Written for commit 3fdb7b25dfaf1bb1aedd4656cf25c5374d724152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/haru/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer environment-variable handling, including trimming and treating blank values as unset.
  * Added supervisor configuration validation and a standardized internal error response.
* **Bug Fixes**
  * Improved URL safety by blocking malformed cross-origin joins.
  * Preserved only explicitly configured fleet policy values while applying defaults when read.
  * Added clearer handling for aborted requests and oversized control requests.
* **Security**
  * Limited control-request body sizes and rejected potentially unsafe URL inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->