### PR TITLE
Add CodeRabbit config (org-standard strict-review baseline)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,283 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit configuration, ported from the arkorlab/arkor org standard and
+# tuned for the STRICTEST possible review.
+#
+# Every knob below is deliberately set to its most rigorous value:
+#   - assertive profile + request-changes workflow + error-level pre-merge checks
+#     are the hard merge gate (the failing commit status is a signal, not the gate)
+#   - title and linked-issue pre-merge checks escalated to "error"; description
+#     and docstring coverage only warn, to match CONTRIBUTING.md's lenient stance
+#   - every linter / security / secret scanner enabled (including ones off by default),
+#     with each tool's own level pushed to its strictest (languagetool picky, phpstan max)
+#   - documented repo conventions (bilingual EN/JA docs parity, the two-linter
+#     oxlint + ESLint setup, supply-chain guards, the CAS / fail-open-data /
+#     fail-closed-control invariants, the publish-safe repo rule, ...) are fed
+#     from their source of truth via knowledge_base.code_guidelines.filePatterns,
+#     so the reviewer applies them without us re-encoding nuanced rules here.
+language: "en-US"
+early_access: false
+enable_free_tier: true
+# Max length is 250 characters; keep this under that or the whole config is
+# rejected and CodeRabbit silently falls back to its (chill) defaults.
+tone_instructions: >-
+  Be rigorous and exhaustive. Flag every bug, security issue, race condition,
+  performance regression, and convention violation, however minor. Do not skip
+  nits; never approve work with a known unresolved issue.
+
+reviews:
+  # Most thorough analysis CodeRabbit offers.
+  profile: "assertive"
+  # Use GitHub's blocking "Request changes" state; only approve once resolved.
+  request_changes_workflow: true
+  high_level_summary: true
+  high_level_summary_in_walkthrough: false
+  review_status: true
+  # Emit the full review-detail breakdown rather than the terse status.
+  review_details: true
+  commit_status: true
+  # Let the CodeRabbit commit status report failure (red) rather than staying
+  # neutral when a review can't complete. The actual merge gate is
+  # request_changes_workflow + the pre_merge_checks below, not this status.
+  fail_commit_status: true
+  collapse_walkthrough: false
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  # Cross-check the PR against its linked issues and related work.
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  enable_prompt_for_ai_agents: true
+  # Stop reviewing as soon as a PR is closed; no wasted runs.
+  abort_on_close: true
+  # Never reuse cached analysis; re-review every change from scratch.
+  disable_cache: true
+  # Keep the review serious and focused, no cosmetic filler.
+  poem: false
+  in_progress_fortune: false
+  path_filters: []
+  path_instructions: []
+
+  # Flag low-effort / AI-slop changes.
+  slop_detection:
+    enabled: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    # Effectively never auto-pause: keep reviewing every pushed commit.
+    auto_pause_after_reviewed_commits: 1000
+    # Review draft PRs too, not just ready-for-review ones.
+    drafts: true
+    ignore_title_keywords: []
+    labels: []
+    base_branches: []
+    ignore_usernames: []
+
+  # Surface as many actionable suggestions as possible.
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+    simplify:
+      enabled: true
+
+  # Pre-merge gate. Title and linked-issue assessment block merge on failure.
+  # Description only warns: CONTRIBUTING.md explicitly says a sparse PR
+  # description is OK and is handled with review follow-ups, so blocking on it
+  # would contradict the documented contributor promise. Docstring coverage
+  # targets 100% but only warns too, since the existing TS code doesn't JSDoc
+  # every function and AGENTS.md's docs conventions govern the bilingual
+  # README/guide pairs and schema-change migrations, not a docstring on every
+  # symbol.
+  pre_merge_checks:
+    # Left at the default (false): restricting overrides to requested reviewers
+    # while auto_assign_reviewers is off can dead-end a PR with no requested
+    # reviewer, where nobody (not even a maintainer) can override a failing
+    # check without first adding one.
+    override_requested_reviewers_only: false
+    docstrings:
+      mode: "warning"
+      threshold: 100
+    title:
+      mode: "error"
+    description:
+      mode: "warning"
+    issue_assessment:
+      mode: "error"
+
+  # Every static-analysis, linter, secret, and security tool ON, each at its
+  # strictest level. Explicitly enumerated so an upstream default flip can't
+  # silently relax coverage.
+  tools:
+    ast-grep:
+      essential_rules: true
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      # Max the schema allows (15 min). This repo's CI fans install / typecheck
+      # / lint / format / test / build through Turbo, plus a separate CodeQL
+      # analysis, so the 90s default would time out before CI finishes and the
+      # review would miss failing checks.
+      timeout_ms: 900000
+    languagetool:
+      enabled: true
+      level: "picky"
+    biome:
+      enabled: true
+    hadolint:
+      enabled: true
+    swiftlint:
+      enabled: true
+    phpstan:
+      enabled: true
+      level: "max"
+    phpmd:
+      enabled: true
+    phpcs:
+      enabled: true
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    checkov:
+      enabled: true
+    tflint:
+      enabled: true
+    detekt:
+      enabled: true
+    eslint:
+      enabled: true
+    flake8:
+      enabled: true
+    # Infer static bug analysis. enable_java defaults false (Java analysis can
+    # need a fuller compile), so opt in explicitly to keep coverage maximal.
+    fbinfer:
+      enabled: true
+      enable_java: true
+    fortitudeLint:
+      enabled: true
+    rubocop:
+      enabled: true
+    buf:
+      enabled: true
+    regal:
+      enabled: true
+    actionlint:
+      enabled: true
+    # Static security analyzer for GitHub Actions workflows.
+    zizmor:
+      enabled: true
+    pmd:
+      enabled: true
+    clang:
+      enabled: true
+    cppcheck:
+      enabled: true
+    opengrep:
+      enabled: true
+    semgrep:
+      enabled: true
+    circleci:
+      enabled: true
+    clippy:
+      enabled: true
+    sqlfluff:
+      enabled: true
+    trivy:
+      enabled: true
+    prismaLint:
+      enabled: true
+    pylint:
+      enabled: true
+    oxc:
+      enabled: true
+    shopifyThemeCheck:
+      enabled: true
+    luacheck:
+      enabled: true
+    brakeman:
+      enabled: true
+    dotenvLint:
+      enabled: true
+    htmlhint:
+      enabled: true
+    stylelint:
+      enabled: true
+    checkmake:
+      enabled: true
+    osvScanner:
+      enabled: true
+    # PII detection, off by default; enabled here for maximum scrutiny.
+    presidio:
+      enabled: true
+    blinter:
+      enabled: true
+    smartyLint:
+      enabled: true
+    emberTemplateLint:
+      enabled: true
+    psscriptanalyzer:
+      enabled: true
+
+chat:
+  # No ASCII art; keep responses focused.
+  art: false
+  # Restrict chat to org members. With Jira/Linear integrations on "auto",
+  # letting non-members trigger auto-replies would let external users on a
+  # public PR make the bot query and summarize internal issue context.
+  allow_non_org_members: false
+  auto_reply: true
+  integrations:
+    jira:
+      usage: "auto"
+    linear:
+      usage: "auto"
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  # Feed the repo's own documented conventions to the reviewer from their source
+  # of truth (bilingual EN/JA docs parity, supply-chain guards, the two-linter
+  # oxlint + ESLint setup, the CAS concurrency model and fail-open-data /
+  # fail-closed-control invariants, the publish-safe repo rule, ...), so it
+  # applies them without us duplicating and risking drift. CodeRabbit also scans
+  # its built-in guideline filenames; these patterns supplement that list, they
+  # don't replace it. Only what is actually written in these files is enforced.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "CONTRIBUTING.md"
+      - "CONTRIBUTING.ja.md"
+      - "**/AGENTS.md"
+      - "**/CLAUDE.md"
+  learnings:
+    scope: "auto"
+  issues:
+    scope: "auto"
+  pull_requests:
+    scope: "auto"
+  jira:
+    usage: "auto"
+  linear:
+    usage: "auto"
+  mcp:
+    usage: "auto"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,13 +1,16 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 #
-# CodeRabbit configuration, ported from the arkorlab/arkor org standard and
-# tuned for the STRICTEST possible review.
+# CodeRabbit configuration, ported from our shared org-standard baseline and
+# tuned for the STRICTEST possible review. (This repo is public, so AGENTS.md
+# forbids naming the private consumer repos this baseline is shared with.)
 #
 # Every knob below is deliberately set to its most rigorous value:
-#   - assertive profile + request-changes workflow + error-level pre-merge checks
-#     are the hard merge gate (the failing commit status is a signal, not the gate)
-#   - title and linked-issue pre-merge checks escalated to "error"; description
-#     and docstring coverage only warn, to match CONTRIBUTING.md's lenient stance
+#   - assertive profile + request-changes workflow + an error-level PR-title
+#     check are the hard merge gate (the failing commit status is a signal, not
+#     the gate)
+#   - the PR-title pre-merge check is escalated to "error"; description,
+#     docstring coverage and linked-issue assessment only warn, to match
+#     CONTRIBUTING.md's lenient stance
 #   - every linter / security / secret scanner enabled (including ones off by default),
 #     with each tool's own level pushed to its strictest (languagetool picky, phpstan max)
 #   - documented repo conventions (bilingual EN/JA docs parity, the two-linter
@@ -88,14 +91,20 @@ reviews:
     simplify:
       enabled: true
 
-  # Pre-merge gate. Title and linked-issue assessment block merge on failure.
-  # Description only warns: CONTRIBUTING.md explicitly says a sparse PR
-  # description is OK and is handled with review follow-ups, so blocking on it
-  # would contradict the documented contributor promise. Docstring coverage
-  # targets 100% but only warns too, since the existing TS code doesn't JSDoc
-  # every function and AGENTS.md's docs conventions govern the bilingual
-  # README/guide pairs and schema-change migrations, not a docstring on every
-  # symbol.
+  # Pre-merge gate. Only the PR title blocks merge on failure. Description,
+  # docstring coverage AND linked-issue assessment only warn, to match this
+  # repo's deliberately lenient contributor policy:
+  #   - CONTRIBUTING.md explicitly says a sparse PR description is OK and is
+  #     handled with review follow-ups, so blocking on it would contradict the
+  #     documented contributor promise.
+  #   - CONTRIBUTING.md welcomes issues but only asks contributors to open one
+  #     FIRST for non-trivial changes; a trivial PR with no linked issue is a
+  #     supported flow, and CodeRabbit can't reliably tell the two apart, so an
+  #     error-level issue gate would request-changes on valid contributions.
+  #   - Docstring coverage targets 100% but only warns, since the existing TS
+  #     code doesn't JSDoc every function and AGENTS.md's docs conventions
+  #     govern the bilingual README/guide pairs and schema-change migrations,
+  #     not a docstring on every symbol.
   pre_merge_checks:
     # Left at the default (false): restricting overrides to requested reviewers
     # while auto_assign_reviewers is off can dead-end a PR with no requested
@@ -110,7 +119,7 @@ reviews:
     description:
       mode: "warning"
     issue_assessment:
-      mode: "error"
+      mode: "warning"
 
   # Every static-analysis, linter, secret, and security tool ON, each at its
   # strictest level. Explicitly enumerated so an upstream default flip can't
@@ -238,16 +247,20 @@ reviews:
 chat:
   # No ASCII art; keep responses focused.
   art: false
-  # Restrict chat to org members. With Jira/Linear integrations on "auto",
-  # letting non-members trigger auto-replies would let external users on a
-  # public PR make the bot query and summarize internal issue context.
+  # Restrict chat to org members regardless: this is a defense-in-depth default
+  # even though the private issue-tracker integrations below are off.
   allow_non_org_members: false
   auto_reply: true
+  # This repo is PUBLIC and its contributor flow runs on GitHub issues (see
+  # CONTRIBUTING.md), not a private tracker. Disable the Jira/Linear lookups so
+  # an org member can't trigger a bot reply that publishes private issue titles
+  # or summaries into a public PR thread. Flip these back on deliberately only
+  # if a tracker is ever wired into the public flow.
   integrations:
     jira:
-      usage: "auto"
+      usage: "disabled"
     linear:
-      usage: "auto"
+      usage: "disabled"
 
 knowledge_base:
   opt_out: false
@@ -275,9 +288,12 @@ knowledge_base:
     scope: "auto"
   pull_requests:
     scope: "auto"
+  # Off for the same reason as the chat integrations above: a public repo whose
+  # flow lives on GitHub issues must not pull private-tracker context into
+  # review summaries.
   jira:
-    usage: "auto"
+    usage: "disabled"
   linear:
-    usage: "auto"
+    usage: "disabled"
   mcp:
     usage: "auto"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,7 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 #
-# CodeRabbit configuration, ported from our shared org-standard baseline and
-# tuned for the STRICTEST possible review. (This repo is public, so AGENTS.md
-# forbids naming the private consumer repos this baseline is shared with.)
+# CodeRabbit configuration, ported from a shared org-standard review baseline
+# and tuned for the STRICTEST possible review.
 #
 # Every knob below is deliberately set to its most rigorous value:
 #   - assertive profile + request-changes workflow + an error-level PR-title
@@ -251,11 +250,12 @@ chat:
   # even though the private issue-tracker integrations below are off.
   allow_non_org_members: false
   auto_reply: true
-  # This repo is PUBLIC and its contributor flow runs on GitHub issues (see
-  # CONTRIBUTING.md), not a private tracker. Disable the Jira/Linear lookups so
-  # an org member can't trigger a bot reply that publishes private issue titles
-  # or summaries into a public PR thread. Flip these back on deliberately only
-  # if a tracker is ever wired into the public flow.
+  # This repo's contributor flow runs on GitHub issues (see CONTRIBUTING.md),
+  # not a private tracker, so Jira/Linear lookups add nothing here. Set them to
+  # an explicit "disabled" rather than "auto": that pins the safe posture
+  # independently of how "auto" resolves per visibility, so no bot reply can
+  # surface private-tracker titles/summaries in a PR thread even if the repo's
+  # visibility or integrations change later.
   integrations:
     jira:
       usage: "disabled"
@@ -288,9 +288,9 @@ knowledge_base:
     scope: "auto"
   pull_requests:
     scope: "auto"
-  # Off for the same reason as the chat integrations above: a public repo whose
-  # flow lives on GitHub issues must not pull private-tracker context into
-  # review summaries.
+  # Off for the same reason as the chat integrations above: this repo's flow
+  # lives on GitHub issues, so keep private-tracker context out of review
+  # summaries explicitly rather than leaving it to "auto".
   jira:
     usage: "disabled"
   linear:


### PR DESCRIPTION
## What

Add `.coderabbit.yaml`, porting the strictest-review CodeRabbit configuration from the arkorlab/arkor org standard.

## Details

The functional config is byte-identical to the org standard (verified: `diff` of comment-stripped values against the reference is empty). Only the explanatory comments are adapted to haru's actual conventions:

- **Header / knowledge-base comments** — reference haru's documented conventions (bilingual EN/JA docs parity, the oxlint + ESLint two-linter setup, supply-chain guards, the CAS / fail-open-data / fail-closed-control invariants, the publish-safe repo rule) instead of arkor's Studio internals.
- **`github-checks.timeout_ms`** — kept the 15-min max, corrected the rationale: haru's CI is single-OS Turbo (install/typecheck/lint/format/test/build) plus a separate CodeQL analysis, not a large OS x Node matrix.
- **`pre_merge_checks.docstrings`** — the warning-mode rationale now cites haru's real doc conventions (bilingual README/guide pairs, schema-change migrations) rather than a per-symbol docstring requirement.

The strict posture is unchanged from the org standard: `assertive` profile, request-changes workflow, error-level title/linked-issue checks, all linter/security/secret tools enabled, cache disabled, drafts reviewed.

## Validation

- YAML parses cleanly; `tone_instructions` is 208 chars (under the 250 hard limit that would otherwise silently reject the file).
- Comment-stripped functional parity with the reference confirmed.

## Notes

- Landing the file only; taking effect still requires the CodeRabbit GitHub App to be installed on the repo/org.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `.coderabbit.yaml` that enforces the org-standard strict review profile with assertive, request-changes reviews and all analyzers enabled. PR title is the only error gate; linked-issue, description, and docstrings warn; `github-checks` timeout is 15 minutes; Jira/Linear integrations are disabled; the knowledge base enforces local guidelines.

- **Migration**
  - Install the CodeRabbit GitHub App on the repo/org.

<sup>Written for commit b8381f7d69b36af38719cf3d41011d1e035bfc17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/haru/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated code review configuration with stricter validation, security, and compliance checks.
  * Improved review behavior and reporting, including stronger PR guidance enforcement and knowledge-based assistance for issues and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->