### PR TITLE
test(db): hold the viable-standby predicate's two copies in sync

### DIFF
--- a/packages/core/src/failover.ts
+++ b/packages/core/src/failover.ts
@@ -43,7 +43,10 @@ export function hasInferenceBindings(domain: DomainSnapshot): boolean {
  * MIRRORED IN SQL: the escalation CAS re-checks this predicate inside
  * its UPDATE statement (escalateDomainIfFleetIdle in @haru/db) so a
  * concurrent heartbeat cannot strip the standby between the in-memory
- * decision and the escalation. Keep the two in sync.
+ * decision and the escalation. The two are held in sync by
+ * `failover-parity.test.ts` in @haru/db, which drives the same database
+ * state through both and asserts they agree - extend it when you add a
+ * condition here.
  */
 function isViableFailoverTarget(
   domain: DomainSnapshot,

--- a/packages/db/src/failover-parity.test.ts
+++ b/packages/db/src/failover-parity.test.ts
@@ -1,0 +1,201 @@
+import { detectDegradedEscalation } from "@haru/core";
+import { fleetLayoutSchema } from "@haru/protocol";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  escalateDomainIfFleetIdle,
+  markDomainSeen,
+  transitionDomain,
+} from "./repo/domains.js";
+import { applyFleetLayout } from "./repo/layout.js";
+import { transitionSlot } from "./repo/slots.js";
+import { getFleetSnapshot } from "./repo/snapshots.js";
+import { createTestDatabase, loadExampleFleetLayout } from "./testing/index.js";
+
+import type { HaruDatabase } from "./client.js";
+import type { FleetSnapshot } from "@haru/protocol";
+
+/**
+ * The viable-standby predicate exists TWICE: as `isViableFailoverTarget`
+ * in @haru/core (which `detectDegradedEscalation` consults in memory) and
+ * inlined as SQL `EXISTS`/`NOT EXISTS` subqueries inside
+ * `escalateDomainIfFleetIdle`, so a concurrent heartbeat cannot strip the
+ * standby between the decision and the escalation. Both source files say
+ * the two must be kept in sync by hand.
+ *
+ * Hand-sync is exactly what a test can replace. These cases drive the
+ * SAME database state through both and assert they agree, so a change to
+ * one side that the other did not follow fails here instead of surfacing
+ * as an escalation that sacrifices the active's healthy models for a
+ * standby the in-memory decision had already rejected.
+ */
+
+const HEARTBEAT_STALE_MS = 30_000;
+const DEGRADED_GRACE_MS = 60_000;
+// Comfortably past the grace so the escalation's OTHER guards are
+// satisfied and only the viability predicate is under test.
+const DEGRADED_FOR_MS = DEGRADED_GRACE_MS * 2;
+
+let database: HaruDatabase;
+let close: () => Promise<void>;
+let fleet: FleetSnapshot;
+
+beforeEach(async () => {
+  ({ db: database, close } = await createTestDatabase());
+  await applyFleetLayout(database, loadExampleFleetLayout());
+  const snapshot = await getFleetSnapshot(database, "default");
+  if (!snapshot) throw new Error("seed failed");
+  fleet = snapshot;
+});
+
+afterEach(async () => {
+  await close();
+});
+
+const active = () => fleet.domains.find((d) => d.slug === "alpha")!;
+const standby = () => fleet.domains.find((d) => d.slug === "beta")!;
+
+/**
+ * Read the live state and ask both implementations the same question.
+ *
+ * The example layout ships `autoFailover: false`, and the SQL helper
+ * takes `heartbeatStaleMs` as an argument rather than reading policy, so
+ * the policy is overridden on the snapshot to put both sides on
+ * identical terms. Domain and slot state - everything the predicate
+ * actually judges - comes from the database in both cases.
+ */
+async function bothVerdicts(now: Date): Promise<{
+  inMemory: boolean;
+  inSql: boolean;
+}> {
+  const live = await getFleetSnapshot(database, "default");
+  if (!live) throw new Error("snapshot vanished");
+  const isInMemory =
+    detectDegradedEscalation(
+      {
+        ...live,
+        policy: {
+          ...live.policy,
+          autoFailover: true,
+          degradedGraceMs: DEGRADED_GRACE_MS,
+          heartbeatStaleMs: HEARTBEAT_STALE_MS,
+        },
+      },
+      now.getTime(),
+    ) !== null;
+  // Run the SQL side second: it MUTATES on success, so a true verdict
+  // must not be able to influence the in-memory read above.
+  const isInSql = await escalateDomainIfFleetIdle(
+    database,
+    active().id,
+    fleet.id,
+    now,
+    HEARTBEAT_STALE_MS,
+  );
+  return { inMemory: isInMemory, inSql: isInSql };
+}
+
+/** Put the active into the degraded-past-grace state both sides require. */
+async function degradeActive(now: Date): Promise<void> {
+  await transitionDomain(
+    database,
+    active().id,
+    ["ready"],
+    "degraded",
+    new Date(now.getTime() - DEGRADED_FOR_MS),
+  );
+}
+
+describe("viable-standby predicate parity (core vs SQL)", () => {
+  it("agrees when the standby is fully viable", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    await markDomainSeen(database, standby().id, now);
+
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(true);
+  });
+
+  it("agrees when the standby has never heartbeated", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    // No markDomainSeen: lastSeenAt stays null. SQL compares
+    // `lastSeenAt >= cutoff` (null fails), core checks `!== null`.
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(false);
+  });
+
+  it("agrees when the standby's heartbeat is stale", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    await markDomainSeen(
+      database,
+      standby().id,
+      new Date(now.getTime() - HEARTBEAT_STALE_MS - 1000),
+    );
+
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(false);
+  });
+
+  it("agrees when the standby is not ready", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    await markDomainSeen(database, standby().id, now);
+    // Ready is required, not merely promotable: a degraded standby's
+    // lastSeenAt still records the last SUCCESS, so freshness alone
+    // would keep treating a just-unreachable supervisor as viable.
+    await transitionDomain(database, standby().id, ["ready"], "degraded");
+
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(false);
+  });
+
+  it("agrees when one of the standby's inference slots is failed", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    await markDomainSeen(database, standby().id, now);
+    const slot = standby().slots.find((s) => s.kind === "inference")!;
+    await transitionSlot(
+      database,
+      slot.id,
+      "inference",
+      ["serving", "sleeping"],
+      "failed",
+    );
+
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(false);
+  });
+
+  /**
+   * The one place the two predicates are NOT literally the same test.
+   * Core requires an inference slot with at least one bound model (a
+   * bindingless target fails the probe step); the SQL only requires an
+   * inference slot to exist, and justifies the simplification with "the
+   * schema guarantees an inference slot binds >= 1 model".
+   *
+   * That makes a zod constraint in a THIRD package load-bearing for a
+   * SQL predicate two packages away, with nothing connecting them.
+   * Relaxing it would silently make the SQL side broader than core's:
+   * the escalation would fire on a standby the in-memory decision
+   * rejected. Pinned here so that relaxation breaks a test instead.
+   */
+  it("keeps the schema invariant the SQL predicate leans on", () => {
+    const layout = loadExampleFleetLayout() as {
+      domains: { slots: { kind: string; models?: unknown[] }[] }[];
+    };
+    const inference = layout.domains[0]?.slots.find(
+      (s) => s.kind === "inference",
+    );
+    if (!inference) throw new Error("example layout has no inference slot");
+    inference.models = [];
+
+    expect(() => fleetLayoutSchema.parse(layout)).toThrow();
+  });
+});

--- a/packages/db/src/failover-parity.test.ts
+++ b/packages/db/src/failover-parity.test.ts
@@ -1,5 +1,6 @@
 import { detectDegradedEscalation } from "@haru/core";
 import { fleetLayoutSchema } from "@haru/protocol";
+import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -10,6 +11,7 @@ import {
 import { applyFleetLayout } from "./repo/layout.js";
 import { transitionSlot } from "./repo/slots.js";
 import { getFleetSnapshot } from "./repo/snapshots.js";
+import { domains, slots } from "./schema/index.js";
 import { createTestDatabase, loadExampleFleetLayout } from "./testing/index.js";
 
 import type { HaruDatabase } from "./client.js";
@@ -95,14 +97,29 @@ async function bothVerdicts(now: Date): Promise<{
   return { inMemory: isInMemory, inSql: isInSql };
 }
 
-/** Put the active into the degraded-past-grace state both sides require. */
+/**
+ * Put the active into the degraded-past-grace state both sides require,
+ * and assert it took.
+ *
+ * The SQL side also guards on the routing pointer and on no operation
+ * being in flight, so a fixture change could make it answer `false` for a
+ * reason that has nothing to do with viability, and these cases would
+ * still "agree" while testing nothing. Pinning the preconditions keeps a
+ * green run meaningful.
+ */
 async function degradeActive(now: Date): Promise<void> {
-  await transitionDomain(
+  const isMoved = await transitionDomain(
     database,
     active().id,
     ["ready"],
     "degraded",
     new Date(now.getTime() - DEGRADED_FOR_MS),
+  );
+  expect(isMoved).toBe(true);
+  const live = await getFleetSnapshot(database, "default");
+  expect(live?.activeDomainId).toBe(active().id);
+  expect(live?.domains.find((d) => d.id === active().id)?.state).toBe(
+    "degraded",
   );
 }
 
@@ -167,6 +184,41 @@ describe("viable-standby predicate parity (core vs SQL)", () => {
       ["serving", "sleeping"],
       "failed",
     );
+
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(false);
+  });
+
+  it("agrees when the standby has no supervisor to drive", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    await markDomainSeen(database, standby().id, now);
+    // No repository helper unbinds a supervisor, and the point is to
+    // exercise the stored state both predicates read, so the column is
+    // cleared directly.
+    await database
+      .update(domains)
+      .set({ supervisorUrl: null })
+      .where(eq(domains.id, standby().id));
+
+    const { inMemory, inSql } = await bothVerdicts(now);
+    expect(inSql).toBe(inMemory);
+    expect(inMemory).toBe(false);
+  });
+
+  it("agrees when the standby has no inference slot at all", async () => {
+    const now = new Date();
+    await degradeActive(now);
+    await markDomainSeen(database, standby().id, now);
+    // Same reasoning as above: layout apply is additive, so removing a
+    // slot is not something the repository layer offers.
+    const standbyId = standby().id;
+    const standbyInferenceSlots = and(
+      eq(slots.domainId, standbyId),
+      eq(slots.kind, "inference"),
+    );
+    await database.delete(slots).where(standbyInferenceSlots);
 
     const { inMemory, inSql } = await bothVerdicts(now);
     expect(inSql).toBe(inMemory);

--- a/packages/db/src/repo/domains.ts
+++ b/packages/db/src/repo/domains.ts
@@ -63,7 +63,8 @@ export async function transitionDomain(
  * `detectDegradedEscalation` bet on (e.g. by failing its only
  * inference slot) - escalating then would drop the active's remaining
  * healthy models with only a doomed failover target left. The
- * viability predicate mirrors core's isViableFailoverTarget: ready
+ * viability predicate mirrors core's isViableFailoverTarget (held in
+ * sync by failover-parity.test.ts, not by hand): ready
  * state, a supervisor URL, at least one inference slot (the schema
  * guarantees an inference slot binds >= 1 model), none of them
  * failed, and a heartbeat no older than the caller's cutoff. A


### PR DESCRIPTION
## What

A parity test for the viable-standby predicate, which currently exists twice:

- `isViableFailoverTarget` in `@haru/core`, consulted in memory by `detectDegradedEscalation`
- the same conditions inlined as `EXISTS` / `NOT EXISTS` subqueries inside `escalateDomainIfFleetIdle`, so a concurrent heartbeat cannot strip the standby between the decision and the escalation

Both source comments end with a request to keep the two in sync by hand. This does that mechanically instead: each case drives the **same database state** through both implementations and asserts the verdicts agree, across the dimensions the predicate judges (fully viable, never heartbeated, stale heartbeat, not ready, failed inference slot).

## Why it is worth a test rather than a comment

Divergence here is not a cosmetic drift. The escalation deliberately sacrifices the active's remaining healthy models on the bet that failover succeeds, so an SQL predicate that is *broader* than core's means the bet gets placed on a standby the in-memory decision had already rejected, and the promotion then fails at the probe step. That is a bad trade made silently.

## Confirming the test can actually fail

A parity test that passes proves nothing on its own, so I checked its sensitivity: deleting `notExists(standbyFailedInferenceSlot)` from the SQL predicate makes the failed-slot case report SQL `true` against core `false` and the test fails with `expected true to be false`. Restored, all six pass.

## One case is a tripwire, not a parity assertion

The two predicates are not literally identical, and the difference is deliberate. Core requires an inference slot with **at least one bound model** (a bindingless target fails the probe step); the SQL requires only that an inference slot exist, justified in the comment with "the schema guarantees an inference slot binds >= 1 model".

That is true today - `models: z.array(modelBindingSchema).min(1)` in `@haru/protocol` - but it makes a zod constraint two packages away load-bearing for a SQL predicate, with nothing connecting them. If that `.min(1)` is ever relaxed (a slot provisioned before binding would be a reasonable motivation), the SQL side silently becomes the broader of the two.

So rather than assert a parity that does not hold, the last case asserts the layout schema still rejects a bindingless inference slot, with a comment explaining which SQL simplification depends on it. Relaxing the constraint breaks a test here instead of quietly widening the escalation.

Happy to drop that case if you would rather keep the schema free to change and instead tighten the SQL to check the binding count.

## Notes

Both source comments now point at the test rather than asking for hand sync. No behavior change, no schema change, so no `db:generate`. Runs on the existing PGlite harness - no GPUs, no cloud, no live database.

`pnpm test` (12/12 tasks), `typecheck`, `lint`, `format:check` all pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a parity test that runs both viable-standby checks—`isViableFailoverTarget` in `@haru/core` and the SQL in `escalateDomainIfFleetIdle`—against the same DB state to keep them in sync and prevent silent divergence. The suite now covers all branches (including missing supervisor URL and missing inference slot) and pins preconditions (routing pointer, no op in flight) so results reflect viability only; also adds a schema tripwire to enforce at least one model per inference slot and updates source comments to point to the test; no behavior changes.

<sup>Written for commit 1200867958e6d4b60b4d2888cd9000c29d859076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/arkorlab/haru/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

